### PR TITLE
Refactoring id()

### DIFF
--- a/lib/include/krado/geom_curve.h
+++ b/lib/include/krado/geom_curve.h
@@ -151,11 +151,8 @@ operator<<(std::ostream & stream, const krado::GeomCurve::CurveType & type)
 inline std::ostream &
 operator<<(std::ostream & stream, const krado::GeomCurve & crv)
 {
-    stream << "Curve " << crv.id() << ": ";
+    stream << "Curve: ";
     stream << "type=" << crv.type() << ", ";
-    auto first_vtx = crv.first_vertex();
-    auto last_vtx = crv.last_vertex();
-    stream << "vertices=[" << first_vtx.id() << ", " << last_vtx.id() << "], ";
     auto [umin, umax] = crv.param_range();
     stream << "u=[" << umin << ", " << umax << "], ";
     stream << "length=" << crv.length();

--- a/lib/include/krado/geom_model.h
+++ b/lib/include/krado/geom_model.h
@@ -16,8 +16,13 @@
 #include "krado/mesh.h"
 #include "krado/bounding_box_3d.h"
 #include "TopTools_DataMapOfShapeInteger.hxx"
-#include <Standard_TypeDef.hxx>
 #include <map>
+
+class TopoDS_Vertex;
+class TopoDS_Edge;
+class TopoDS_Face;
+class TopoDS_Shell;
+class TopoDS_Solid;
 
 namespace krado {
 
@@ -138,6 +143,12 @@ protected:
     [[nodiscard]] ShapeID volume_id(const GeomVolume & volume) const;
 
 private:
+    ShapeID get_shape_id(const TopoDS_Vertex & vertex);
+    ShapeID get_shape_id(const TopoDS_Edge & edge);
+    ShapeID get_shape_id(const TopoDS_Face & face);
+    ShapeID get_shape_id(const TopoDS_Shell & shell);
+    ShapeID get_shape_id(const TopoDS_Solid & solid);
+
     void bind_shape(const GeomShape & shape);
     void bind_vertices(const GeomShape & shape);
     void bind_edges(const GeomShape & shape);

--- a/lib/include/krado/geom_shape.h
+++ b/lib/include/krado/geom_shape.h
@@ -26,16 +26,6 @@ public:
                                       SEW_FACES | MAKE_SOLIDS);
     void scale(double scale_factor);
 
-    /// Get the unique identifier of the shape
-    ///
-    /// @return The unique identifier of the shape.
-    ShapeID id() const;
-
-    /// Set the unique identifier of the shape
-    ///
-    /// @param id The unique identifier of the shape.
-    void set_id(ShapeID id);
-
     /// Query if this shape has material assigned to it
     ///
     /// @return `true` if material is assigned, `false` otherwise
@@ -81,7 +71,6 @@ private:
 
     int dim_;
     TopoDS_Shape shape_;
-    ShapeID id_;
     /// Color of this shape
     Color clr_;
     /// Material name

--- a/lib/include/krado/geom_surface.h
+++ b/lib/include/krado/geom_surface.h
@@ -109,13 +109,7 @@ bool is_circular_face(const GeomSurface & surface);
 inline std::ostream &
 operator<<(std::ostream & stream, const krado::GeomSurface & srf)
 {
-    stream << "Surface " << srf.id() << ": ";
-    auto crvs = srf.curves();
-    std::vector<krado::ShapeID> cids;
-    cids.reserve(crvs.size());
-    for (auto c : crvs)
-        cids.push_back(c.id());
-    stream << "curves=[" << krado::join(", ", cids) << "], ";
+    stream << "Surface: ";
     auto [u_min, u_max] = srf.param_range(0);
     auto [v_min, v_max] = srf.param_range(1);
     stream << "u=[" << u_min << ", " << u_max << "], ";

--- a/lib/include/krado/geom_vertex.h
+++ b/lib/include/krado/geom_vertex.h
@@ -41,6 +41,7 @@ private:
 inline std::ostream &
 operator<<(std::ostream & stream, const krado::GeomVertex & vtx)
 {
-    stream << "Vertex " << vtx.id() << ": location=" << vtx.point();
+    auto pt = vtx.point();
+    stream << "Vertex: location=(x=" << pt.x << ", y=" << pt.y << ", z=" << pt.z << ")";
     return stream;
 }

--- a/lib/include/krado/mesh_curve.h
+++ b/lib/include/krado/mesh_curve.h
@@ -19,7 +19,7 @@ class MeshCurveVertex;
 
 class MeshCurve : public Meshable {
 public:
-    MeshCurve(const GeomCurve & gcurve, Ptr<MeshVertex> v1, Ptr<MeshVertex> v2);
+    MeshCurve(ShapeID id, const GeomCurve & gcurve, Ptr<MeshVertex> v1, Ptr<MeshVertex> v2);
 
     /// Get the unique identifier of the curve.
     ///
@@ -116,6 +116,9 @@ public:
     }
 
 private:
+    ///
+    ShapeID id_;
+    ///
     const GeomCurve & gcurve_;
     /// All vertices on this curve
     std::vector<Ptr<MeshVertexAbstract>> vtxs_;

--- a/lib/include/krado/mesh_surface.h
+++ b/lib/include/krado/mesh_surface.h
@@ -19,7 +19,9 @@ class MeshCurve;
 
 class MeshSurface : public Meshable {
 public:
-    MeshSurface(const GeomSurface & gcurve, const std::vector<Ptr<MeshCurve>> & mesh_curves);
+    MeshSurface(ShapeID id,
+                const GeomSurface & gcurve,
+                const std::vector<Ptr<MeshCurve>> & mesh_curves);
 
     /// Get the unique identifier of the surface.
     ///
@@ -112,6 +114,9 @@ public:
     }
 
 private:
+    ///
+    ShapeID id_;
+    ///
     const GeomSurface & gsurface_;
     /// Mesh curves bounding this surface
     std::vector<Ptr<MeshCurve>> mesh_curves_;

--- a/lib/include/krado/mesh_vertex.h
+++ b/lib/include/krado/mesh_vertex.h
@@ -14,7 +14,7 @@ class Point;
 
 class MeshVertex : public MeshVertexAbstract, public Meshable {
 public:
-    MeshVertex(const GeomVertex & geom_vertex);
+    MeshVertex(ShapeID id, const GeomVertex & geom_vertex);
 
     /// Get the unique identifier of the vertex.
     ///
@@ -42,6 +42,9 @@ public:
     void set_mesh_size(double size);
 
 private:
+    ///
+    ShapeID id_;
+    ///
     const GeomVertex & gvtx_;
     /// Mesh size at the vertex.
     double mesh_size_;

--- a/lib/include/krado/mesh_volume.h
+++ b/lib/include/krado/mesh_volume.h
@@ -14,7 +14,9 @@ class MeshSurface;
 
 class MeshVolume : public Meshable {
 public:
-    MeshVolume(const GeomVolume & gvolume, const std::vector<Ptr<MeshSurface>> & mesh_surfaces);
+    MeshVolume(ShapeID id,
+               const GeomVolume & gvolume,
+               const std::vector<Ptr<MeshSurface>> & mesh_surfaces);
 
     /// Get the unique identifier of the volume.
     ///
@@ -50,6 +52,9 @@ public:
     }
 
 private:
+    ///
+    ShapeID id_;
+    ///
     const GeomVolume & gvolume_;
     /// Mesh surfaces bounding this surface
     std::vector<Ptr<MeshSurface>> mesh_surfaces_;

--- a/lib/include/krado/types.h
+++ b/lib/include/krado/types.h
@@ -68,9 +68,21 @@ public:
         return this->value_ < other;
     }
 
+    ShapeID &
+    operator++()
+    {
+        ++this->value_;
+        return *this;
+    }
+
 private:
     int32 value_;
+
+public:
+    static const ShapeID INVALID;
 };
+
+inline constexpr ShapeID ShapeID::INVALID { -1 };
 
 /// Marker type
 class Marker {

--- a/lib/src/geom_curve.cpp
+++ b/lib/src/geom_curve.cpp
@@ -3,6 +3,7 @@
 
 #include "krado/geom_curve.h"
 #include "krado/geom_surface.h"
+#include "krado/geom_model.h"
 #include "krado/exception.h"
 #include "TopoDS.hxx"
 #include "BRep_Tool.hxx"
@@ -183,7 +184,7 @@ Point
 get_circle_center(const GeomCurve & crv)
 {
     if (crv.type() != GeomCurve::CurveType::Circle)
-        throw Exception("Curve {} is not a circle", crv.id());
+        throw Exception("Curve is not a circle");
 
     const Handle(Geom_Circle) & circle = Handle(Geom_Circle)::DownCast(crv.curve_);
     gp_Pnt center = circle->Location();

--- a/lib/src/geom_model.cpp
+++ b/lib/src/geom_model.cpp
@@ -19,6 +19,7 @@
 #include "TopoDS_Vertex.hxx"
 #include "TopoDS_Edge.hxx"
 #include "TopoDS_Face.hxx"
+#include "TopoDS_Shell.hxx"
 #include "TopoDS_Solid.hxx"
 
 namespace krado {
@@ -166,8 +167,6 @@ GeomModel::volume_id(const GeomVolume & volume) const
 void
 GeomModel::bind_shape(const GeomShape & shape)
 {
-    Log::debug("Binding shape {}", shape.id());
-
     bind_vertices(shape);
     bind_edges(shape);
     bind_faces(shape);
@@ -181,12 +180,12 @@ GeomModel::bind_solids(const GeomShape & shape)
     for (exp0.Init(shape, TopAbs_SOLID); exp0.More(); exp0.Next()) {
         TopoDS_Solid solid = TopoDS::Solid(exp0.Current());
         if (!this->vol_id_.IsBound(solid)) {
-            ShapeID id = this->vols_.size() + 1;
+            auto id = get_shape_id(solid);
+            this->vol_id_.Bind(solid, id.value());
+
             GeomVolume gvol(solid);
-            gvol.set_id(id);
             gvol.set_material(shape.material(), shape.density());
             this->vols_.emplace(id, gvol);
-            this->vol_id_.Bind(solid, id.value());
         }
     }
 }
@@ -198,12 +197,12 @@ GeomModel::bind_faces(const GeomShape & shape)
     for (exp0.Init(shape, TopAbs_FACE); exp0.More(); exp0.Next()) {
         TopoDS_Face face = TopoDS::Face(exp0.Current());
         if (!this->srf_id_.IsBound(face)) {
-            ShapeID id = this->srfs_.size() + 1;
+            auto id = get_shape_id(face);
+            this->srf_id_.Bind(face, id.value());
+
             GeomSurface gsurf(face);
-            gsurf.set_id(id);
             gsurf.set_material(shape.material(), shape.density());
             this->srfs_.emplace(id, gsurf);
-            this->srf_id_.Bind(face, id.value());
         }
     }
 }
@@ -215,12 +214,12 @@ GeomModel::bind_edges(const GeomShape & shape)
     for (exp0.Init(shape, TopAbs_EDGE); exp0.More(); exp0.Next()) {
         TopoDS_Edge edge = TopoDS::Edge(exp0.Current());
         if (!this->crv_id_.IsBound(edge)) {
-            ShapeID id = this->crvs_.size() + 1;
+            auto id = get_shape_id(edge);
+            this->crv_id_.Bind(edge, id.value());
+
             GeomCurve gedge(edge);
-            gedge.set_id(id);
             gedge.set_material(shape.material(), shape.density());
             this->crvs_.emplace(id, gedge);
-            this->crv_id_.Bind(edge, id.value());
         }
     }
 }
@@ -232,12 +231,12 @@ GeomModel::bind_vertices(const GeomShape & shape)
     for (exp0.Init(shape, TopAbs_VERTEX); exp0.More(); exp0.Next()) {
         TopoDS_Vertex vertex = TopoDS::Vertex(exp0.Current());
         if (!this->vtx_id_.IsBound(vertex)) {
-            ShapeID id = this->vtxs_.size() + 1;
+            auto id = get_shape_id(vertex);
+            this->vtx_id_.Bind(vertex, id.value());
+
             GeomVertex gvtx(vertex);
-            gvtx.set_id(id);
             gvtx.set_material(shape.material(), shape.density());
             this->vtxs_.emplace(id, gvtx);
-            this->vtx_id_.Bind(vertex, id.value());
         }
     }
 }
@@ -246,7 +245,7 @@ void
 GeomModel::initialize()
 {
     for (auto & [id, gvtx] : this->vtxs_) {
-        auto mvtx = Ptr<MeshVertex>::alloc(gvtx);
+        auto mvtx = Ptr<MeshVertex>::alloc(id, gvtx);
         this->mvtxs_.emplace(id, mvtx);
     }
 
@@ -256,7 +255,7 @@ GeomModel::initialize()
         auto v1 = vertex(id1);
         auto v2 = vertex(id2);
 
-        auto mesh_crv = Ptr<MeshCurve>::alloc(geom_curve, v1, v2);
+        auto mesh_crv = Ptr<MeshCurve>::alloc(id, geom_curve, v1, v2);
         this->mcrvs_.emplace(id, mesh_crv);
     }
 
@@ -269,7 +268,7 @@ GeomModel::initialize()
             mesh_curves.push_back(mcurve);
         }
 
-        auto mesh_surf = Ptr<MeshSurface>::alloc(geom_surface, mesh_curves);
+        auto mesh_surf = Ptr<MeshSurface>::alloc(id, geom_surface, mesh_curves);
         this->msurfs_.emplace(id, mesh_surf);
     }
 
@@ -282,7 +281,7 @@ GeomModel::initialize()
             mesh_surfaces.push_back(msurface);
         }
 
-        auto mesh_vol = Ptr<MeshVolume>::alloc(geom_volume, mesh_surfaces);
+        auto mesh_vol = Ptr<MeshVolume>::alloc(id, geom_volume, mesh_surfaces);
         this->mvols_.emplace(id, mesh_vol);
     }
 }
@@ -600,6 +599,71 @@ GeomModel::build_surface_mesh()
     auto elements = build_surface_elements();
     Mesh mesh(points, elements);
     return mesh;
+}
+
+ShapeID
+GeomModel::get_shape_id(const TopoDS_Vertex & vertex)
+{
+    if (!this->vtx_id_.IsBound(vertex)) {
+        ShapeID id = this->vtxs_.size() + 1;
+        this->vtx_id_.Bind(vertex, id.value());
+        return id;
+    }
+    else {
+        return this->vtx_id_.Find(vertex);
+    }
+}
+
+ShapeID
+GeomModel::get_shape_id(const TopoDS_Edge & edge)
+{
+    if (!this->crv_id_.IsBound(edge)) {
+        ShapeID id = this->crvs_.size() + 1;
+        this->crv_id_.Bind(edge, id.value());
+        return id;
+    }
+    else {
+        return this->crv_id_.Find(edge);
+    }
+}
+
+ShapeID
+GeomModel::get_shape_id(const TopoDS_Face & face)
+{
+    if (!this->srf_id_.IsBound(face)) {
+        ShapeID id = this->srfs_.size() + 1;
+        this->srf_id_.Bind(face, id.value());
+        return id;
+    }
+    else {
+        return this->srf_id_.Find(face);
+    }
+}
+
+ShapeID
+GeomModel::get_shape_id(const TopoDS_Shell & shell)
+{
+    if (!this->vol_id_.IsBound(shell)) {
+        ShapeID id = this->vols_.size() + 1;
+        this->vol_id_.Bind(shell, id.value());
+        return id;
+    }
+    else {
+        return this->vol_id_.Find(shell);
+    }
+}
+
+ShapeID
+GeomModel::get_shape_id(const TopoDS_Solid & solid)
+{
+    if (!this->vol_id_.IsBound(solid)) {
+        ShapeID id = this->vols_.size() + 1;
+        this->vol_id_.Bind(solid, id.value());
+        return id;
+    }
+    else {
+        return this->vol_id_.Find(solid);
+    }
 }
 
 } // namespace krado

--- a/lib/src/geom_shape.cpp
+++ b/lib/src/geom_shape.cpp
@@ -45,26 +45,14 @@ get_next_color()
 
 } // namespace
 
-GeomShape::GeomShape(const TopoDS_Shape & shape) : dim_(-1), shape_(shape), id_(-1) {}
+GeomShape::GeomShape(const TopoDS_Shape & shape) : dim_(-1), shape_(shape) {}
 
-GeomShape::GeomShape(int dim, const TopoDS_Shape & shape) : dim_(dim), shape_(shape), id_(-1) {}
+GeomShape::GeomShape(int dim, const TopoDS_Shape & shape) : dim_(dim), shape_(shape) {}
 
 int
 GeomShape::dim() const
 {
     return this->dim_;
-}
-
-ShapeID
-GeomShape::id() const
-{
-    return this->id_;
-}
-
-void
-GeomShape::set_id(ShapeID id)
-{
-    this->id_ = id;
 }
 
 bool

--- a/lib/src/geom_shell.cpp
+++ b/lib/src/geom_shell.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "krado/geom_shell.h"
+#include "krado/geom_model.h"
 #include "TopoDS.hxx"
 #include "TopExp_Explorer.hxx"
 

--- a/lib/src/geom_surface.cpp
+++ b/lib/src/geom_surface.cpp
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "krado/geom_surface.h"
-#include "krado/exception.h"
 #include "krado/geom_shape.h"
+#include "krado/geom_model.h"
+#include "krado/exception.h"
 #include "TopoDS.hxx"
 #include "BRep_Tool.hxx"
 #include "BRepGProp.hxx"

--- a/lib/src/geom_vertex.cpp
+++ b/lib/src/geom_vertex.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "krado/geom_vertex.h"
+#include "krado/geom_model.h"
 #include "BRep_Tool.hxx"
 
 namespace krado {

--- a/lib/src/geom_volume.cpp
+++ b/lib/src/geom_volume.cpp
@@ -3,6 +3,7 @@
 
 #include "krado/geom_volume.h"
 #include "krado/geom_surface.h"
+#include "krado/geom_model.h"
 #include "TopoDS.hxx"
 #include "BRepGProp.hxx"
 #include "GProp_GProps.hxx"

--- a/lib/src/mesh_curve.cpp
+++ b/lib/src/mesh_curve.cpp
@@ -13,7 +13,8 @@
 
 namespace krado {
 
-MeshCurve::MeshCurve(const GeomCurve & gcurve, Ptr<MeshVertex> v1, Ptr<MeshVertex> v2) :
+MeshCurve::MeshCurve(ShapeID id, const GeomCurve & gcurve, Ptr<MeshVertex> v1, Ptr<MeshVertex> v2) :
+    id_(id),
     gcurve_(gcurve),
     too_smoll(false)
 {
@@ -27,7 +28,7 @@ MeshCurve::MeshCurve(const GeomCurve & gcurve, Ptr<MeshVertex> v1, Ptr<MeshVerte
 ShapeID
 MeshCurve::id() const
 {
-    return this->gcurve_.id();
+    return this->id_;
 }
 
 const GeomCurve &

--- a/lib/src/mesh_surface.cpp
+++ b/lib/src/mesh_surface.cpp
@@ -14,8 +14,10 @@
 
 namespace krado {
 
-MeshSurface::MeshSurface(const GeomSurface & gsurface,
+MeshSurface::MeshSurface(ShapeID id,
+                         const GeomSurface & gsurface,
                          const std::vector<Ptr<MeshCurve>> & mesh_curves) :
+    id_(id),
     gsurface_(gsurface),
     mesh_curves_(mesh_curves)
 {
@@ -24,7 +26,7 @@ MeshSurface::MeshSurface(const GeomSurface & gsurface,
 ShapeID
 MeshSurface::id() const
 {
-    return this->gsurface_.id();
+    return this->id_;
 }
 
 const GeomSurface &

--- a/lib/src/mesh_vertex.cpp
+++ b/lib/src/mesh_vertex.cpp
@@ -8,8 +8,9 @@
 
 namespace krado {
 
-MeshVertex::MeshVertex(const GeomVertex & geom_vertex) :
+MeshVertex::MeshVertex(ShapeID id, const GeomVertex & geom_vertex) :
     MeshVertexAbstract(geom_vertex),
+    id_(id),
     gvtx_(geom_vertex),
     mesh_size_(MAX_LC)
 {
@@ -18,7 +19,7 @@ MeshVertex::MeshVertex(const GeomVertex & geom_vertex) :
 ShapeID
 MeshVertex::id() const
 {
-    return this->gvtx_.id();
+    return this->id_;
 }
 
 const GeomVertex &

--- a/lib/src/mesh_volume.cpp
+++ b/lib/src/mesh_volume.cpp
@@ -9,8 +9,10 @@
 
 namespace krado {
 
-MeshVolume::MeshVolume(const GeomVolume & gvolume,
+MeshVolume::MeshVolume(ShapeID id,
+                       const GeomVolume & gvolume,
                        const std::vector<Ptr<MeshSurface>> & mesh_surfaces) :
+    id_(id),
     gvolume_(gvolume),
     mesh_surfaces_(mesh_surfaces)
 {
@@ -19,7 +21,7 @@ MeshVolume::MeshVolume(const GeomVolume & gvolume,
 ShapeID
 MeshVolume::id() const
 {
-    return this->gvolume_.id();
+    return this->id_;
 }
 
 const GeomVolume &

--- a/lib/src/ops.cpp
+++ b/lib/src/ops.cpp
@@ -34,8 +34,6 @@ namespace krado {
 std::tuple<GeomCurve, GeomCurve>
 split_curve(const GeomCurve & curve, Standard_Real split_param)
 {
-    Log::info("Splitting curve {} at parameter u={}", curve.id(), split_param);
-
     double umin, umax;
     Handle(Geom_Curve) orig_curve = BRep_Tool::Curve(curve, umin, umax);
     if (split_param < umin || split_param > umax)
@@ -53,8 +51,6 @@ split_curve(const GeomCurve & curve, Standard_Real split_param)
 GeomShell
 imprint(const GeomSurface & surface, const GeomCurve & curve)
 {
-    Log::info("Imprinting curve {} onto surface {}", curve.id(), surface.id());
-
     BRepAlgo_NormalProjection projection(surface);
     projection.Add(curve);
     projection.Build();
@@ -83,8 +79,6 @@ imprint(const GeomSurface & surface, const GeomCurve & curve)
 GeomVolume
 imprint(const GeomVolume & volume, const GeomCurve & curve)
 {
-    Log::info("Imprinting volume {} with curve {}", volume.id(), curve.id());
-
     BRepAlgo_NormalProjection projection(volume);
     // arbitrary distance limit, shapes must be close together
     projection.SetMaxDistance(1e-10);
@@ -113,8 +107,6 @@ imprint(const GeomVolume & volume, const GeomCurve & curve)
 GeomVolume
 imprint(const GeomVolume & volume, const GeomVolume & imp_vol)
 {
-    Log::info("Imprinting volume {} with volume {}", volume.id(), imp_vol.id());
-
     TopTools_ListOfShape args;
     args.Append(volume);
 

--- a/lib/src/scheme/tricircle.cpp
+++ b/lib/src/scheme/tricircle.cpp
@@ -40,7 +40,7 @@ SchemeTriCircle::mesh_surface(Ptr<MeshSurface> mesh_surface)
 
     const auto & gsurf = mesh_surface->geom_surface();
     if (!is_circular_face(gsurf))
-        throw Exception("Surface {} is not a circle", gsurf.id());
+        throw Exception("Surface {} is not a circle", mesh_surface->id());
 
     auto n_radial = this->opts_.radial_intervals;
     if (n_radial <= 0)

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -221,8 +221,6 @@ PYBIND11_MODULE(krado, m)
         .def("clean", &GeomShape::clean)
         .def("heal", &GeomShape::heal)
         .def("scale", &GeomShape::scale)
-        .def("id", &GeomShape::id)
-        .def("set_id", &GeomShape::set_id)
         .def("has_material", &GeomShape::has_material)
         .def("set_material", &GeomShape::set_material)
         .def("material", &GeomShape::material)
@@ -376,7 +374,7 @@ PYBIND11_MODULE(krado, m)
     ;
 
     py::class_<MeshVertex, MeshVertexAbstract>(m, "MeshVertex")
-        .def(py::init<const GeomVertex &>())
+        .def(py::init<ShapeID, const GeomVertex &>())
         .def("id", &MeshVertex::id)
         .def("point", &MeshVertex::point)
         .def("mesh_size", &MeshVertex::mesh_size)
@@ -397,7 +395,7 @@ PYBIND11_MODULE(krado, m)
     ;
 
     py::class_<MeshCurve, Meshable>(m, "MeshCurve")
-        .def(py::init<const GeomCurve &, Ptr<MeshVertex>, Ptr<MeshVertex>>())
+        .def(py::init<ShapeID, const GeomCurve &, Ptr<MeshVertex>, Ptr<MeshVertex>>())
         .def("id", &MeshCurve::id)
         .def("all_vertices", &MeshCurve::all_vertices, py::return_value_policy::reference)
         .def("bounding_vertices", &MeshCurve::bounding_vertices, py::return_value_policy::reference)
@@ -413,7 +411,7 @@ PYBIND11_MODULE(krado, m)
     ;
 
     py::class_<MeshSurface, Meshable>(m, "MeshSurface")
-        .def(py::init<const GeomSurface &, const std::vector<Ptr<MeshCurve>> &>())
+        .def(py::init<ShapeID, const GeomSurface &, const std::vector<Ptr<MeshCurve>> &>())
         .def("id", &MeshSurface::id)
         .def("curves", &MeshSurface::curves, py::return_value_policy::reference)
         .def("all_vertices", py::overload_cast<>(&MeshSurface::all_vertices, py::const_), py::return_value_policy::reference)
@@ -433,7 +431,7 @@ PYBIND11_MODULE(krado, m)
     ;
 
     py::class_<MeshVolume, Meshable>(m, "MeshVolume")
-        .def(py::init<const GeomVolume &, const std::vector<Ptr<MeshSurface>> &>())
+        .def(py::init<ShapeID, const GeomVolume &, const std::vector<Ptr<MeshSurface>> &>())
         .def("id", &MeshVolume::id)
         .def("surfaces", &MeshVolume::surfaces, py::return_value_policy::reference)
     ;

--- a/test/src/GeomCurve_test.cpp
+++ b/test/src/GeomCurve_test.cpp
@@ -3,6 +3,9 @@
 #include "krado/geom_surface.h"
 #include "krado/ops.h"
 #include "krado/exception.h"
+#include "krado/geom_model.h"
+#include "krado/mesh_curve_vertex.h"
+#include "krado/mesh_surface_vertex.h"
 #include "builder.h"
 
 using namespace krado;
@@ -186,5 +189,5 @@ TEST(GeomCurveTest, op_shl)
     auto line = testing::build_line(Point(0, 0, 0), Point(3, 4, 0));
     std::stringstream ss;
     ss << line;
-    EXPECT_EQ(ss.str(), "Curve -1: type=line, vertices=[-1, -1], u=[0, 5], length=5");
+    EXPECT_EQ(ss.str(), "Curve: type=line, u=[0, 5], length=5");
 }

--- a/test/src/GeomSurface_test.cpp
+++ b/test/src/GeomSurface_test.cpp
@@ -139,5 +139,5 @@ TEST(GeomSurfaceTest, op_shl)
     auto circ = testing::build_circle(Point(0, 0, 0), 2.);
     std::stringstream ss;
     ss << circ;
-    EXPECT_EQ(ss.str(), "Surface -1: curves=[-1], u=[-2, 2], v=[-2, 2], area=12.5664");
+    EXPECT_EQ(ss.str(), "Surface: u=[-2, 2], v=[-2, 2], area=12.5664");
 }

--- a/test/src/GeomVertex_test.cpp
+++ b/test/src/GeomVertex_test.cpp
@@ -38,5 +38,5 @@ TEST(GeomVertexTest, op_shl)
     auto vtx = testing::build_vertex(Point(1, 2, 3));
     std::stringstream ss;
     ss << vtx;
-    EXPECT_EQ(ss.str(), "Vertex -1: location=(x = 1, y = 2, z = 3)");
+    EXPECT_EQ(ss.str(), "Vertex: location=(x=1, y=2, z=3)");
 }

--- a/test/src/MeshCurve_test.cpp
+++ b/test/src/MeshCurve_test.cpp
@@ -13,9 +13,9 @@ TEST(MeshCurveTest, DISABLED_api)
 {
     auto edge = testing::build_line(Point(0, 0, 0), Point(3, 4, 0));
 
-    auto v1 = Ptr<MeshVertex>::alloc(edge.first_vertex());
-    auto v2 = Ptr<MeshVertex>::alloc(edge.last_vertex());
-    MeshCurve mcurve(edge, v1, v2);
+    auto v1 = Ptr<MeshVertex>::alloc(1, edge.first_vertex());
+    auto v2 = Ptr<MeshVertex>::alloc(2, edge.last_vertex());
+    MeshCurve mcurve(1, edge, v1, v2);
 
     EXPECT_EQ(&mcurve.geom_curve(), &edge);
 
@@ -33,9 +33,9 @@ TEST(MeshCurveTest, mesh)
     auto gvtx1 = edge.first_vertex();
     auto gvtx2 = edge.last_vertex();
 
-    auto v1 = Ptr<MeshVertex>::alloc(gvtx1);
-    auto v2 = Ptr<MeshVertex>::alloc(gvtx2);
-    auto mcurve = Ptr<MeshCurve>::alloc(edge, v1, v2);
+    auto v1 = Ptr<MeshVertex>::alloc(1, gvtx1);
+    auto v2 = Ptr<MeshVertex>::alloc(2, gvtx2);
+    auto mcurve = Ptr<MeshCurve>::alloc(1, edge, v1, v2);
 
     SchemeEqual::Options opts;
     opts.intervals = 4;

--- a/test/src/MeshSurface_test.cpp
+++ b/test/src/MeshSurface_test.cpp
@@ -16,10 +16,10 @@ TEST(MeshSurfaceTest, api)
     GeomSurface gsurf(circ);
     auto crvs = gsurf.curves();
     ASSERT_EQ(crvs.size(), 1);
-    auto mcurve = Ptr<MeshCurve>::alloc(crvs[0], Ptr<MeshVertex>(), Ptr<MeshVertex>());
+    auto mcurve = Ptr<MeshCurve>::alloc(1, crvs[0], Ptr<MeshVertex>(), Ptr<MeshVertex>());
 
     std::vector<Ptr<MeshCurve>> c = { mcurve };
-    auto msurface = Ptr<MeshSurface>::alloc(gsurf, c);
+    auto msurface = Ptr<MeshSurface>::alloc(1, gsurf, c);
     EXPECT_EQ(&msurface->geom_surface(), &gsurf);
 
     // EXPECT_EQ(msurface->scheme().name(), "auto");

--- a/test/src/MeshVertex_test.cpp
+++ b/test/src/MeshVertex_test.cpp
@@ -11,7 +11,7 @@ TEST(MeshVertexTest, api)
     auto vtx = testing::build_vertex(Point(3, 4, 0));
     GeomVertex gvertex(vtx);
 
-    MeshVertex mvertex(gvertex);
+    MeshVertex mvertex(1, gvertex);
 
     EXPECT_EQ(&mvertex.geom_vertex(), &gvertex);
     EXPECT_EQ(mvertex.global_id(), 0);

--- a/test/src/MeshVolume_test.cpp
+++ b/test/src/MeshVolume_test.cpp
@@ -17,13 +17,14 @@ TEST(MeshVolumeTest, api)
     auto surfs = gvol.surfaces();
     ASSERT_EQ(surfs.size(), 6);
 
+    ShapeID surf_id = 0;
     std::vector<Ptr<MeshSurface>> msurfs;
     for (auto & gs : surfs) {
         std::vector<Ptr<MeshCurve>> c;
-        msurfs.emplace_back(Ptr<MeshSurface>::alloc(gs, c));
+        msurfs.emplace_back(Ptr<MeshSurface>::alloc(++surf_id, gs, c));
     }
 
-    auto mvol = Ptr<MeshVolume>::alloc(gvol, msurfs);
+    auto mvol = Ptr<MeshVolume>::alloc(1, gvol, msurfs);
     EXPECT_EQ(&mvol->geom_volume(), &gvol);
 
     // EXPECT_EQ(mvol->scheme().name(), "auto");


### PR DESCRIPTION
- geometrical shapes do not have ID
- mesh entities like vertices, curves, surfaces, etc. do
