### PR TITLE
Adding support for quad4 into `MeshSurface`

### DIFF
--- a/lib/include/krado/mesh_surface.h
+++ b/lib/include/krado/mesh_surface.h
@@ -77,6 +77,13 @@ public:
 
     [[nodiscard]] std::vector<MeshElement> & triangles();
 
+    /// Get quadrangles on this surface
+    ///
+    /// @return Quadrangles on this surface
+    [[nodiscard]] const std::vector<MeshElement> & quadrangles() const;
+
+    [[nodiscard]] std::vector<MeshElement> & quadrangles();
+
     /// Add vertex
     ///
     /// @param vertex Vertex to add

--- a/lib/include/krado/utils.h
+++ b/lib/include/krado/utils.h
@@ -275,4 +275,18 @@ std::array<Ptr<MeshVertexAbstract>, 3> ccw_triangle(const GeomSurface & gsurf,
                                                     Ptr<MeshVertexAbstract> b,
                                                     Ptr<MeshVertexAbstract> c);
 
+/// Create a counter-clock-wise quadrangle
+///
+/// @param gsurf Geomterical surface
+/// @param a Vertex A
+/// @param b Vertex B
+/// @param c Vertex C
+/// @param d Vertex D
+/// @return Counter-clockwise quadrangle
+std::array<Ptr<MeshVertexAbstract>, 4> ccw_quadrangle(const GeomSurface & gsurf,
+                                                      Ptr<MeshVertexAbstract> a,
+                                                      Ptr<MeshVertexAbstract> b,
+                                                      Ptr<MeshVertexAbstract> c,
+                                                      Ptr<MeshVertexAbstract> d);
+
 } // namespace krado

--- a/lib/src/geom_model.cpp
+++ b/lib/src/geom_model.cpp
@@ -97,13 +97,29 @@ build_2d_elements(const GeomModel & model)
         std::vector<Element> elems;
         for (auto & [id, surface] : model.surfaces()) {
             auto & tris = surface->triangles();
-            std::array<gidx_t, Tri3::N_VERTICES> tri;
-            for (auto & local_elem : tris) {
-                for (int i = 0; i < Tri3::N_VERTICES; ++i) {
-                    auto vtx = local_elem.vertex(i);
-                    tri[i] = vtx->global_id();
+            auto & quads = surface->quadrangles();
+            if (tris.size() > 0 and quads.size() == 0) {
+                std::array<gidx_t, Tri3::N_VERTICES> tri;
+                for (auto & local_elem : tris) {
+                    for (int i = 0; i < Tri3::N_VERTICES; ++i) {
+                        auto vtx = local_elem.vertex(i);
+                        tri[i] = vtx->global_id();
+                    }
+                    elems.emplace_back(Element::Tri3(tri));
                 }
-                elems.emplace_back(Element::Tri3(tri));
+            }
+            else if (quads.size() > 0 and tris.size() == 0) {
+                std::array<gidx_t, Quad4::N_VERTICES> quad;
+                for (auto & local_elem : quads) {
+                    for (int i = 0; i < Quad4::N_VERTICES; ++i) {
+                        auto vtx = local_elem.vertex(i);
+                        quad[i] = vtx->global_id();
+                    }
+                    elems.emplace_back(Element::Quad4(quad));
+                }
+            }
+            else if (quads.size() > 0 and tris.size() > 0) {
+                throw Exception("Heterogeneous meshes are not supported, yet");
             }
         }
         return elems;

--- a/lib/src/mesh_surface.cpp
+++ b/lib/src/mesh_surface.cpp
@@ -105,6 +105,18 @@ MeshSurface::triangles()
     return this->tris_;
 }
 
+const std::vector<MeshElement> &
+MeshSurface::quadrangles() const
+{
+    return this->quads_;
+}
+
+std::vector<MeshElement> &
+MeshSurface::quadrangles()
+{
+    return this->quads_;
+}
+
 void
 MeshSurface::add_vertex(Ptr<MeshVertex> vertex)
 {
@@ -143,6 +155,8 @@ MeshSurface::add_element(MeshElement tri)
 {
     if (tri.type() == ElementType::TRI3)
         this->tris_.emplace_back(tri);
+    else if (tri.type() == ElementType::QUAD4)
+        this->quads_.emplace_back(tri);
     else
         throw Exception("Unsupported element type");
 }
@@ -178,6 +192,7 @@ MeshSurface::delete_mesh()
     this->vtxs_.clear();
     this->surf_vtxs_.clear();
     this->tris_.clear();
+    this->quads_.clear();
 }
 
 bool

--- a/lib/src/utils.cpp
+++ b/lib/src/utils.cpp
@@ -156,4 +156,24 @@ ccw_triangle(const GeomSurface & gsurf,
         throw Exception("Degenerate triangle detected. Points are collinear.");
 }
 
+std::array<Ptr<MeshVertexAbstract>, 4>
+ccw_quadrangle(const GeomSurface & gsurf,
+               Ptr<MeshVertexAbstract> a,
+               Ptr<MeshVertexAbstract> b,
+               Ptr<MeshVertexAbstract> c,
+               Ptr<MeshVertexAbstract> d)
+{
+    auto uv_a = gsurf.parameter_from_point(a->point());
+    auto uv_b = gsurf.parameter_from_point(b->point());
+    auto uv_c = gsurf.parameter_from_point(c->point());
+
+    auto orientation = orient2d(uv_a, uv_b, uv_c);
+    if (orientation > 0)
+        return std::array<Ptr<MeshVertexAbstract>, 4> { a, b, c, d };
+    else if (orientation < 0)
+        return std::array<Ptr<MeshVertexAbstract>, 4> { a, d, c, b };
+    else
+        throw Exception("Degenerate quadrangle detected.");
+}
+
 } // namespace krado


### PR DESCRIPTION
- Can add quads into `MeshSurface`
- Adding `ccw_quadrangle`
- Adding support to store quad4 for 2D meshes
