### PR TITLE
Updating python wrappers

### DIFF
--- a/lib/include/krado/ptr.h
+++ b/lib/include/krado/ptr.h
@@ -216,9 +216,9 @@ public:
         return this->ctrl_ == nullptr;
     }
 
-private:
     explicit Ptr(T * ptr) : ctrl_(new ControlBlock(ptr)) {}
 
+private:
     void
     release()
     {

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -56,6 +56,8 @@
 namespace py = pybind11;
 using namespace krado;
 
+PYBIND11_DECLARE_HOLDER_TYPE(T, krado::Ptr<T>);
+
 class PyMeshVertexAbstract : public MeshVertexAbstract {
 public:
     using MeshVertexAbstract::MeshVertexAbstract;
@@ -273,20 +275,30 @@ PYBIND11_MODULE(krado, m)
              py::arg("ax2"), py::arg("pt1"), py::arg("n_sides"))
     ;
 
+    py::class_<ShapeID>(m, "ShapeID")
+        .def(py::init<int32>())
+        .def("value", &ShapeID::value)
+    ;
+
+    py::class_<Marker>(m, "Marker")
+        .def(py::init<int32>())
+        .def("value", &Marker::value)
+    ;
+
     py::class_<GeomModel>(m, "GeomModel")
         .def(py::init<const GeomShape &>())
         .def("vertices", &GeomModel::vertices, py::return_value_policy::reference)
-        .def("vertex", py::overload_cast<ShapeID>(&GeomModel::vertex), py::return_value_policy::reference)
+        .def("vertex", [](GeomModel & self, int32 id) { return self.vertex(ShapeID(id)); })
         .def("curves", &GeomModel::curves, py::return_value_policy::reference)
-        .def("curve", py::overload_cast<ShapeID>(&GeomModel::curve), py::return_value_policy::reference)
+        .def("curve", [](GeomModel & self, int32 id) { return self.curve(ShapeID(id)); })
         .def("surfaces", &GeomModel::surfaces, py::return_value_policy::reference)
-        .def("surface", py::overload_cast<ShapeID>(&GeomModel::surface), py::return_value_policy::reference)
+        .def("surface", [](GeomModel & self, int32 id) { return self.surface(ShapeID(id)); })
         .def("volumes", &GeomModel::volumes, py::return_value_policy::reference)
-        .def("volume", py::overload_cast<ShapeID>(&GeomModel::volume), py::return_value_policy::reference)
-        .def("mesh_vertex", py::overload_cast<ShapeID>(&GeomModel::mesh_vertex))
-        .def("mesh_curve", py::overload_cast<ShapeID>(&GeomModel::mesh_curve))
-        .def("mesh_surface", py::overload_cast<ShapeID>(&GeomModel::mesh_surface))
-        .def("mesh_volume", py::overload_cast<ShapeID>(&GeomModel::mesh_volume))
+        .def("volume", [](GeomModel & self, int32 id) { return self.volume(ShapeID(id)); })
+        .def("mesh_vertex", [](GeomModel & self, int32 id) { self.mesh_vertex(ShapeID(id)); })
+        .def("mesh_curve", [](GeomModel & self, int32 id) { self.mesh_curve(ShapeID(id)); })
+        .def("mesh_surface", [](GeomModel & self, int32 id) { self.mesh_surface(ShapeID(id)); })
+        .def("mesh_volume", [](GeomModel & self, int32 id) { self.mesh_volume(ShapeID(id)); })
     ;
 
     py::class_<GeomVertex>(m, "GeomVertex")
@@ -473,11 +485,11 @@ PYBIND11_MODULE(krado, m)
         .def("outward_normal", &Mesh::outward_normal)
     ;
 
-    py::class_<Meshable>(m, "Meshable")
+    py::class_<Meshable, Ptr<Meshable>>(m, "Meshable")
         .def(py::init<>())
         .def("is_meshed", &Meshable::is_meshed)
-        .def("set_marker", &Meshable::set_marker)
-        .def("marker", &Meshable::marker)
+        .def("set_marker", [](Meshable & self, int32 m) { self.set_marker(Marker(m)); })
+        .def("marker", [](const Meshable & self) { return self.marker().value(); })
     ;
 
     py::class_<MeshElement>(m, "MeshElement")
@@ -490,13 +502,13 @@ PYBIND11_MODULE(krado, m)
         .def("swap_vertices", &MeshElement::swap_vertices)
     ;
 
-    py::class_<MeshVertexAbstract, PyMeshVertexAbstract>(m, "MeshVertexAbstract")
+    py::class_<MeshVertexAbstract, PyMeshVertexAbstract, Ptr<MeshVertexAbstract>>(m, "MeshVertexAbstract")
         .def("point", &MeshVertexAbstract::point)
         .def("global_id", &MeshVertexAbstract::global_id)
         .def("set_global_id", &MeshVertexAbstract::set_global_id)
     ;
 
-    py::class_<MeshVertex, MeshVertexAbstract>(m, "MeshVertex")
+    py::class_<MeshVertex, MeshVertexAbstract, Ptr<MeshVertex>>(m, "MeshVertex")
         .def(py::init<ShapeID, const GeomVertex &>())
         .def("id", &MeshVertex::id)
         .def("point", &MeshVertex::point)
@@ -504,20 +516,20 @@ PYBIND11_MODULE(krado, m)
         .def("set_mesh_size", &MeshVertex::set_mesh_size)
     ;
 
-    py::class_<MeshCurveVertex, MeshVertexAbstract>(m, "MeshCurveVertex")
+    py::class_<MeshCurveVertex, MeshVertexAbstract, Ptr<MeshCurveVertex>>(m, "MeshCurveVertex")
         .def(py::init<const GeomCurve &, double>())
         .def("parameter", &MeshCurveVertex::parameter)
         .def("point", &MeshCurveVertex::point)
     ;
 
-    py::class_<MeshSurfaceVertex, MeshVertexAbstract>(m, "MeshSurfaceVertex")
+    py::class_<MeshSurfaceVertex, MeshVertexAbstract, Ptr<MeshSurfaceVertex>>(m, "MeshSurfaceVertex")
         .def(py::init<const GeomSurface &, double, double>())
         .def(py::init<const GeomSurface &, UVParam>())
         .def("parameter", &MeshSurfaceVertex::parameter)
         .def("point", &MeshSurfaceVertex::point)
     ;
 
-    py::class_<MeshCurve, Meshable>(m, "MeshCurve")
+    py::class_<MeshCurve, Meshable, Ptr<MeshCurve>>(m, "MeshCurve")
         .def(py::init<ShapeID, const GeomCurve &, Ptr<MeshVertex>, Ptr<MeshVertex>>())
         .def("id", &MeshCurve::id)
         .def("bounding_vertices", &MeshCurve::bounding_vertices, py::return_value_policy::reference)
@@ -531,7 +543,7 @@ PYBIND11_MODULE(krado, m)
         .def("set_mesh_size", &MeshCurve::set_mesh_size)
     ;
 
-    py::class_<MeshSurface, Meshable>(m, "MeshSurface")
+    py::class_<MeshSurface, Meshable, Ptr<MeshSurface>>(m, "MeshSurface")
         .def(py::init<ShapeID, const GeomSurface &, const std::vector<Ptr<MeshCurve>> &>())
         .def("id", &MeshSurface::id)
         .def("curves", &MeshSurface::curves, py::return_value_policy::reference)
@@ -548,7 +560,7 @@ PYBIND11_MODULE(krado, m)
         .def("delete_mesh", &MeshSurface::delete_mesh)
     ;
 
-    py::class_<MeshVolume, Meshable>(m, "MeshVolume")
+    py::class_<MeshVolume, Meshable, Ptr<MeshVolume>>(m, "MeshVolume")
         .def(py::init<ShapeID, const GeomVolume &, const std::vector<Ptr<MeshSurface>> &>())
         .def("id", &MeshVolume::id)
         .def("surfaces", &MeshVolume::surfaces, py::return_value_policy::reference)

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -612,7 +612,14 @@ PYBIND11_MODULE(krado, m)
     m.def("extrude", static_cast<Mesh(*)(const Mesh &, const Vector &, int, double)>(&extrude));
     m.def("extrude", static_cast<Mesh(*)(const Mesh &, const Vector &, const std::vector<double> &)>(&extrude));
 
-    m.def("compute_volume", &compute_volume);
+    m.def("compute_volume", [](const Mesh & mesh) {
+        auto vols = compute_volume(mesh);
+        py::dict py_vols;
+        for (const auto & [marker, volume] : vols) {
+            py_vols[py::cast(marker.value())] = volume;
+        }
+        return py_vols;
+    });
     m.def("combine", &combine);
 
     m.def("build_mesh", &build_mesh);

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -462,28 +462,115 @@ PYBIND11_MODULE(krado, m)
         .def("compute_bounding_box", &Mesh::compute_bounding_box)
         .def("duplicate", &Mesh::duplicate)
 
-        .def("set_cell_set", &Mesh::set_cell_set)
-        .def("set_cell_set_name", &Mesh::set_cell_set_name)
-        .def("cell_set_name", &Mesh::cell_set_name)
-        .def("cell_set_ids", &Mesh::cell_set_ids)
-        .def("cell_set", &Mesh::cell_set)
+        .def("set_cell_set",
+             [](Mesh & self, int32 id, const std::vector<gidx_t> & cell_ids) {
+                 self.set_cell_set(Marker(id), cell_ids);
+             })
+        .def("set_cell_set_name",
+             [](Mesh & self, int32 cell_set_id, const std::string & name) {
+                 self.set_cell_set_name(Marker(cell_set_id), name);
+             })
+        .def("cell_set_name",
+             [](const Mesh & self, int32 cell_set_id) {
+                 return self.cell_set_name(Marker(cell_set_id));
+             })
+        .def("cell_set_ids",
+             [](const Mesh & self) {
+                 std::vector<int32> ids;
+                 for (const auto & marker : self.cell_set_ids())
+                     ids.push_back(marker.value());
+                 return ids;
+             })
+        .def("cell_set",
+             [](const Mesh & self, int32 id) {
+                 return self.cell_set(Marker(id));
+             }, py::return_value_policy::reference)
         .def("remove_cell_sets", &Mesh::remove_cell_sets)
 
-        .def("set_face_set", &Mesh::set_face_set)
-        .def("set_face_set_name", &Mesh::set_face_set_name)
-        .def("face_set_name", &Mesh::face_set_name)
-        .def("face_set_ids", &Mesh::face_set_ids)
-        .def("face_set", &Mesh::face_set)
+        .def("set_face_set",
+             [](Mesh & self, int32 id, const std::vector<gidx_t> & face_ids) {
+                 self.set_face_set(Marker(id), face_ids);
+             })
+        .def("set_face_set_name",
+             [](Mesh & self, int32 face_set_id, const std::string & name) {
+                 self.set_face_set_name(Marker(face_set_id), name);
+             })
+        .def("face_set_name",
+             [](const Mesh & self, int32 face_set_id) {
+                 return self.face_set_name(Marker(face_set_id));
+             })
+        .def("face_set_ids",
+             [](const Mesh & self) {
+                 std::vector<int32> ids;
+                 for (const auto & marker : self.face_set_ids())
+                     ids.push_back(marker.value());
+                 return ids;
+             })
+        .def("face_set",
+             [](const Mesh & self, int32 id) {
+                 return self.face_set(Marker(id));
+             }, py::return_value_policy::reference)
         .def("remove_face_sets", &Mesh::remove_face_sets)
 
-        .def("set_edge_set", &Mesh::set_edge_set)
-        .def("set_edge_set_name", &Mesh::set_edge_set_name)
-        .def("edge_set_name", &Mesh::edge_set_name)
-        .def("edge_set_ids", &Mesh::edge_set_ids)
-        .def("edge_set", &Mesh::edge_set)
+        .def("set_edge_set",
+             [](Mesh & self, int32 id, const std::vector<gidx_t> & edge_ids) {
+                 self.set_edge_set(Marker(id), edge_ids);
+             })
+        .def("set_edge_set_name",
+             [](Mesh & self, int32 edge_set_id, const std::string & name) {
+                 self.set_edge_set_name(Marker(edge_set_id), name);
+             })
+        .def("edge_set_name",
+             [](const Mesh & self, int32 edge_set_id) {
+                 return self.edge_set_name(Marker(edge_set_id));
+             })
+        .def("edge_set_ids",
+             [](const Mesh & self) {
+                 std::vector<int32> ids;
+                 for (const auto & marker : self.edge_set_ids())
+                     ids.push_back(marker.value());
+                 return ids;
+             })
+        .def("edge_set",
+             [](const Mesh & self, int32 id) {
+                 return self.edge_set(Marker(id));
+             }, py::return_value_policy::reference)
         .def("remove_edge_sets", &Mesh::remove_edge_sets)
 
-        .def("remap_block_ids", &Mesh::remap_block_ids)
+        .def("set_vertex_set_name",
+             [](Mesh & self, int32 id, const std::string & name) {
+                 self.set_vertex_set_name(Marker(id), name);
+             })
+        .def("vertex_set_name",
+             [](const Mesh & self, int32 id) {
+                 return self.vertex_set_name(Marker(id));
+             })
+        .def("vertex_set_ids",
+             [](const Mesh & self) {
+                 std::vector<int32> ids;
+                 for (const auto & marker : self.vertex_set_ids())
+                     ids.push_back(marker.value());
+                 return ids;
+             })
+        .def("vertex_set",
+             [](const Mesh & self, int32 id) {
+                 return self.vertex_set(Marker(id));
+             }, py::return_value_policy::reference)
+        .def("set_vertex_set",
+             [](Mesh & self, int32 id, const std::vector<gidx_t> & vertex_ids) {
+                 self.set_vertex_set(Marker(id), vertex_ids);
+             })
+        .def("remove_vertex_sets", &Mesh::remove_vertex_sets)
+
+        .def("remap_block_ids",
+             [](Mesh & self, const py::dict & block_map_py) {
+                 std::map<Marker, Marker> block_map_cpp;
+                 for (auto item : block_map_py) {
+                     block_map_cpp[Marker(item.first.cast<int32>())] =
+                         Marker(item.second.cast<int32>());
+                 }
+                 self.remap_block_ids(block_map_cpp);
+             })
         .def("vertex_range", &Mesh::vertex_range)
         .def("edge_range", &Mesh::edge_range)
         .def("face_range", &Mesh::face_range)

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -386,6 +386,10 @@ PYBIND11_MODULE(krado, m)
     ;
 
     py::class_<GeomSurface, GeomShape>(m, "GeomSurface")
+        .def(py::init([](const Wire & wire) {
+                return GeomSurface::create(wire);
+             }),
+             py::arg("wire"))
         .def("point", &GeomSurface::point)
         .def("normal", &GeomSurface::normal)
         .def("d1", &GeomSurface::d1)

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -9,6 +9,16 @@
 #include "krado/axis2.h"
 #include "krado/box.h"
 #include "krado/bounding_box_3d.h"
+#include "krado/scheme/bamg.h"
+#include "krado/scheme/bias.h"
+#include "krado/scheme/curvature.h"
+#include "krado/scheme/equal.h"
+#include "krado/scheme/pinpoint.h"
+#include "krado/scheme/size.h"
+#include "krado/scheme/structured.h"
+#include "krado/scheme/triangle.h"
+#include "krado/scheme/tricircle.h"
+#include "krado/scheme/trisurf.h"
 #include "krado/circle.h"
 #include "krado/circumscribed_polygon.h"
 #include "krado/cone.h"
@@ -544,6 +554,46 @@ PYBIND11_MODULE(krado, m)
         .def("mesh_size_at_param", &MeshCurve::mesh_size_at_param)
         .def("mesh_size", &MeshCurve::mesh_size)
         .def("set_mesh_size", &MeshCurve::set_mesh_size)
+        .def("set_scheme",
+             [](MeshCurve & self, const std::string & name, py::kwargs kwargs) {
+                 if (name == "equal") {
+                     SchemeEqual::Options opts;
+                     if (kwargs.contains("intervals"))
+                         opts.intervals = kwargs["intervals"].cast<int>();
+                     self.set_scheme<SchemeEqual>(opts);
+                 }
+                 else if (name == "bias") {
+                     SchemeBias::Options opts;
+                     if (kwargs.contains("intervals"))
+                         opts.intervals = kwargs["intervals"].cast<int>();
+                     if (kwargs.contains("factor"))
+                         opts.factor = kwargs["factor"].cast<double>();
+                     self.set_scheme<SchemeBias>(opts);
+                 }
+                 else if (name == "curvature") {
+                     SchemeCurvature::Options opts;
+                     if (kwargs.contains("min_size"))
+                         opts.min_size = kwargs["min_size"].cast<double>();
+                     if (kwargs.contains("max_size"))
+                         opts.max_size = kwargs["max_size"].cast<double>();
+                     if (kwargs.contains("deflection"))
+                         opts.deflection = kwargs["deflection"].cast<double>();
+                     self.set_scheme<SchemeCurvature>(opts);
+                 }
+                 else if (name == "pinpoint") {
+                     SchemePinpoint::Options opts;
+                     if (kwargs.contains("positions"))
+                         opts.positions = kwargs["positions"].cast<std::vector<double>>();
+                     self.set_scheme<SchemePinpoint>(opts);
+                 }
+                 else if (name == "size") {
+                     SchemeSize::Options opts;
+                     if (kwargs.contains("intervals"))
+                         opts.intervals = kwargs["intervals"].cast<int>();
+                     self.set_scheme<SchemeSize>(opts);
+                 }
+             },
+             "Set the meshing scheme for the curve.")
     ;
 
     py::class_<MeshSurface, Meshable, Ptr<MeshSurface>>(m, "MeshSurface")
@@ -561,12 +611,55 @@ PYBIND11_MODULE(krado, m)
         .def("elements", &MeshSurface::elements)
         .def("remove_all_triangles", &MeshSurface::remove_all_triangles)
         .def("delete_mesh", &MeshSurface::delete_mesh)
+        .def("set_scheme",
+             [](MeshSurface & self, const std::string & name, py::kwargs kwargs) {
+                 if (name == "bamg") {
+                     SchemeBAMG::Options opts;
+                     if (kwargs.contains("max_area"))
+                         opts.max_area = kwargs["max_area"].cast<double>();
+                     self.set_scheme<SchemeBAMG>(opts);
+                 }
+                 else if (name == "structured") {
+                     SchemeStructured::Options opts;
+                     self.set_scheme<SchemeStructured>(opts);
+                 }
+                 else if (name == "triangle") {
+                     SchemeTriangle::Options opts;
+                     if (kwargs.contains("region_point"))
+                         opts.region_point =
+                             kwargs["region_point"].cast<std::tuple<double, double>>();
+                     if (kwargs.contains("max_area"))
+                         opts.max_area = kwargs["max_area"].cast<double>();
+                     self.set_scheme<SchemeTriangle>(opts);
+                 }
+                 else if (name == "tricircle") {
+                     SchemeTriCircle::Options opts;
+                     if (kwargs.contains("radial_intervals"))
+                         opts.radial_intervals = kwargs["radial_intervals"].cast<int>();
+                     self.set_scheme<SchemeTriCircle>(opts);
+                 }
+             },
+             "Set the meshing scheme for the surface.")
     ;
 
     py::class_<MeshVolume, Meshable, Ptr<MeshVolume>>(m, "MeshVolume")
         .def(py::init<ShapeID, const GeomVolume &, const std::vector<Ptr<MeshSurface>> &>())
         .def("id", &MeshVolume::id)
         .def("surfaces", &MeshVolume::surfaces, py::return_value_policy::reference)
+        .def("set_scheme",
+             [](MeshVolume & self, const std::string & name, py::kwargs kwargs) {
+                 if (name == "trisurf") {
+                     SchemeTriSurf::Options opts;
+                     if (kwargs.contains("linear_deflection"))
+                         opts.linear_deflection = kwargs["linear_deflection"].cast<double>();
+                     if (kwargs.contains("angular_deflection"))
+                         opts.angular_deflection = kwargs["angular_deflection"].cast<double>();
+                     if (kwargs.contains("is_relative"))
+                         opts.is_relative = kwargs["is_relative"].cast<bool>();
+                     self.set_scheme<SchemeTriSurf>(opts);
+                 }
+             },
+             "Set the meshing scheme for the volume.")
     ;
 
     py::class_<ExodusIIFile>(m, "ExodusIIFile")

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -301,7 +301,7 @@ PYBIND11_MODULE(krado, m)
         .def("mesh_volume", [](GeomModel & self, int32 id) { self.mesh_volume(ShapeID(id)); })
     ;
 
-    py::class_<GeomVertex>(m, "GeomVertex")
+    py::class_<GeomVertex, GeomShape>(m, "GeomVertex")
         .def(py::init<const TopoDS_Vertex &>())
         .def("x", &GeomVertex::x)
         .def("y", &GeomVertex::y)
@@ -310,7 +310,7 @@ PYBIND11_MODULE(krado, m)
         .def("is_null", &GeomVertex::is_null)
     ;
 
-    py::class_<GeomCurve>(m, "GeomCurve")
+    py::class_<GeomCurve, GeomShape>(m, "GeomCurve")
         .def(py::init<const TopoDS_Edge &>())
         .def("type", &GeomCurve::type)
         .def("is_degenerated", &GeomCurve::is_degenerated)
@@ -385,8 +385,7 @@ PYBIND11_MODULE(krado, m)
              py::arg("start_angle") = 0.)
     ;
 
-    py::class_<GeomSurface>(m, "GeomSurface")
-        .def(py::init<const TopoDS_Face &>())
+    py::class_<GeomSurface, GeomShape>(m, "GeomSurface")
         .def("point", &GeomSurface::point)
         .def("normal", &GeomSurface::normal)
         .def("d1", &GeomSurface::d1)
@@ -398,7 +397,7 @@ PYBIND11_MODULE(krado, m)
         .def("contains_point", &GeomSurface::contains_point)
     ;
 
-    py::class_<GeomVolume>(m, "GeomVolume")
+    py::class_<GeomVolume, GeomShape>(m, "GeomVolume")
         .def(py::init<const TopoDS_Solid &>())
         .def("volume", &GeomVolume::volume)
         .def("surfaces", &GeomVolume::surfaces)

--- a/python/tests/test_geom_model.py
+++ b/python/tests/test_geom_model.py
@@ -45,3 +45,16 @@ def test_geom_model_indexing():
 def test_shape_id_class():
     sid = krado.ShapeID(5)
     assert sid.value() == 5
+
+
+def test_build_from_geom_surface():
+    pt1 = krado.Point(0, 0, 0)
+    pt2 = krado.Point(1, 0, 0)
+    pt3 = krado.Point(1, 1, 0)
+    poly = krado.Polygon([pt1, pt2, pt3])
+
+    surf = krado.GeomSurface(poly)
+    model = krado.GeomModel(surf)
+
+    surfs = model.surfaces()
+    assert len(surfs) > 0

--- a/python/tests/test_geom_model.py
+++ b/python/tests/test_geom_model.py
@@ -1,46 +1,49 @@
-import pytest
-import krado
 import os
+
+import krado
+import pytest
 
 root_dir = os.path.normpath(os.path.join(__file__, "..", "..", ".."))
 assets_dir = os.path.join(root_dir, "test", "assets")
+
 
 def test_geom_model_indexing():
     file_name = os.path.join(assets_dir, "box.step")
     step = krado.STEPFile(file_name)
     shapes = step.load()
     model = krado.GeomModel(shapes[0])
-    
+
     # Test that we can access elements using integers (ShapeID wrapping)
     # The box.step should have some vertices, curves, surfaces, volumes
-    
+
     # Vertices
     verts = model.vertices()
     assert len(verts) > 0
     v1 = model.vertex(1)
     assert isinstance(v1, krado.MeshVertex)
-    
+
     # Curves
     curves = model.curves()
     assert len(curves) > 0
     c1 = model.curve(1)
     assert isinstance(c1, krado.MeshCurve)
-    
+
     # Test method call on Ptr-held object
     c1.set_marker(104)
     assert c1.marker() == 104
-    
+
     # Surfaces
     surfs = model.surfaces()
     assert len(surfs) > 0
     s1 = model.surface(1)
     assert isinstance(s1, krado.MeshSurface)
-    
+
     # Volumes
     vols = model.volumes()
     assert len(vols) > 0
     vol1 = model.volume(1)
     assert isinstance(vol1, krado.MeshVolume)
+
 
 def test_shape_id_class():
     sid = krado.ShapeID(5)

--- a/python/tests/test_geom_model.py
+++ b/python/tests/test_geom_model.py
@@ -1,0 +1,47 @@
+import pytest
+import krado
+import os
+
+root_dir = os.path.normpath(os.path.join(__file__, "..", "..", ".."))
+assets_dir = os.path.join(root_dir, "test", "assets")
+
+def test_geom_model_indexing():
+    file_name = os.path.join(assets_dir, "box.step")
+    step = krado.STEPFile(file_name)
+    shapes = step.load()
+    model = krado.GeomModel(shapes[0])
+    
+    # Test that we can access elements using integers (ShapeID wrapping)
+    # The box.step should have some vertices, curves, surfaces, volumes
+    
+    # Vertices
+    verts = model.vertices()
+    assert len(verts) > 0
+    v1 = model.vertex(1)
+    assert isinstance(v1, krado.MeshVertex)
+    
+    # Curves
+    curves = model.curves()
+    assert len(curves) > 0
+    c1 = model.curve(1)
+    assert isinstance(c1, krado.MeshCurve)
+    
+    # Test method call on Ptr-held object
+    c1.set_marker(104)
+    assert c1.marker() == 104
+    
+    # Surfaces
+    surfs = model.surfaces()
+    assert len(surfs) > 0
+    s1 = model.surface(1)
+    assert isinstance(s1, krado.MeshSurface)
+    
+    # Volumes
+    vols = model.volumes()
+    assert len(vols) > 0
+    vol1 = model.volume(1)
+    assert isinstance(vol1, krado.MeshVolume)
+
+def test_shape_id_class():
+    sid = krado.ShapeID(5)
+    assert sid.value() == 5

--- a/python/tests/test_mesh.py
+++ b/python/tests/test_mesh.py
@@ -1,0 +1,53 @@
+import pytest
+import krado
+import os
+import math
+
+root_dir = os.path.normpath(os.path.join(__file__, "..", "..", ".."))
+assets_dir = os.path.join(root_dir, "test", "assets")
+
+def test_mesh_set_cell_set_name():
+    mesh = krado.Mesh()
+    mesh.set_cell_set_name(1, "test_cell_set")
+    assert mesh.cell_set_name(1) == "test_cell_set"
+
+def test_mesh_cell_set_ids():
+    mesh = krado.Mesh()
+    mesh.set_cell_set_name(1, "test_cell_set_1")
+    mesh.set_cell_set(1, [0]) # Add a dummy cell to make the ID appear
+    mesh.set_cell_set_name(2, "test_cell_set_2")
+    mesh.set_cell_set(2, [1]) # Add a dummy cell to make the ID appear
+    ids = mesh.cell_set_ids()
+    assert isinstance(ids, list)
+    assert 1 in ids
+    assert 2 in ids
+
+def test_mesh_set_cell_set():
+    mesh = krado.Mesh()
+    mesh.set_cell_set(1, [0, 1, 2])
+    cell_set = mesh.cell_set(1)
+    assert cell_set == [0, 1, 2]
+
+def test_mesh_remove_cell_sets():
+    mesh = krado.Mesh()
+    mesh.set_cell_set_name(1, "test_cell_set")
+    mesh.set_cell_set(1, [0, 1, 2])
+    mesh.remove_cell_sets()
+    assert not mesh.cell_set_ids()
+
+def test_mesh_remap_block_ids():
+    # This requires a mesh with blocks, so we'll load one or create a dummy structure
+    # For simplicity, we'll test the binding logic, assuming C++ remap works.
+    mesh = krado.Mesh()
+    mesh.set_cell_set(10, [0, 1])
+    mesh.set_cell_set(20, [2, 3])
+
+    initial_ids = mesh.cell_set_ids()
+    assert 10 in initial_ids and 20 in initial_ids
+
+    remap = {10: 100, 20: 200}
+    mesh.remap_block_ids(remap)
+
+    remapped_ids = mesh.cell_set_ids()
+    assert 100 in remapped_ids and 200 in remapped_ids
+    assert 10 not in remapped_ids and 20 not in remapped_ids

--- a/python/tests/test_scheme.py
+++ b/python/tests/test_scheme.py
@@ -1,0 +1,35 @@
+import pytest
+import krado
+import os
+
+root_dir = os.path.normpath(os.path.join(__file__, "..", "..", ".."))
+assets_dir = os.path.join(root_dir, "test", "assets")
+
+def test_set_scheme_curve():
+    file_name = os.path.join(assets_dir, "box.step")
+    step = krado.STEPFile(file_name)
+    shapes = step.load()
+    model = krado.GeomModel(shapes[0])
+
+    curve = model.curve(1)
+    curve.set_scheme("equal", intervals=50)
+    # We can't really check the scheme was set without more API,
+    # but we can at least check that the method doesn't throw.
+
+def test_set_scheme_surface():
+    file_name = os.path.join(assets_dir, "box.step")
+    step = krado.STEPFile(file_name)
+    shapes = step.load()
+    model = krado.GeomModel(shapes[0])
+
+    surface = model.surface(1)
+    surface.set_scheme("triangle", max_area=0.1)
+
+def test_set_scheme_volume():
+    file_name = os.path.join(assets_dir, "box.step")
+    step = krado.STEPFile(file_name)
+    shapes = step.load()
+    model = krado.GeomModel(shapes[0])
+
+    volume = model.volume(1)
+    volume.set_scheme("trisurf", linear_deflection=0.1, angular_deflection=0.1, is_relative=True)


### PR DESCRIPTION
- Updating wrappers around API that used `ShapeID` and `Marker`
- python: Correcting inheritance on GeomShape-derived classes
- python: `GeomSurface` can be constructed from a Wire
- python: Adding test for construction GeomModel from a GeomShape-derived class
- python: formatting
- python: Updating `compute_volume` wrapper
- Adding python wrapper for `set_scheme`
- python: updating Mesh wrappers to use `Marker`
