### PR TITLE
Adding `MeshSurface::quads_to_tris`

### DIFF
--- a/lib/include/krado/mesh_surface.h
+++ b/lib/include/krado/mesh_surface.h
@@ -94,6 +94,11 @@ public:
 
     void add_element(MeshElement tri);
 
+    /// Convert all quadrangles to triangles
+    ///
+    /// @param mode Splitting mode
+    void quads_to_tris(QuadSplitMode mode = QuadSplitMode::SPLIT2);
+
     /// Reserve memory for vertices and triangles
     void reserve_mem(std::size_t n_vtxs, std::size_t n_tris);
 

--- a/lib/include/krado/types.h
+++ b/lib/include/krado/types.h
@@ -76,4 +76,11 @@ operator==(const SideEntry & lhs, const SideEntry & rhs)
     return lhs.elem == rhs.elem && lhs.side == rhs.side;
 }
 
+enum class QuadSplitMode {
+    /// Split into 2 triangles
+    SPLIT2,
+    /// Split into 4 triangles
+    SPLIT4
+};
+
 } // namespace krado

--- a/lib/src/mesh_surface.cpp
+++ b/lib/src/mesh_surface.cpp
@@ -137,6 +137,34 @@ MeshSurface::add_element(MeshElement tri)
 }
 
 void
+MeshSurface::quads_to_tris(QuadSplitMode mode)
+{
+    if (this->quads_.empty())
+        return;
+
+    for (const auto & quad : this->quads_) {
+        auto v = quad.vertices();
+        if (mode == QuadSplitMode::SPLIT2) {
+            add_triangle({ v[0], v[1], v[2] });
+            add_triangle({ v[2], v[3], v[0] });
+        }
+        else if (mode == QuadSplitMode::SPLIT4) {
+            const auto & gsurf = geom_surface();
+            Point center_pt =
+                0.25 * (v[0]->point() + v[1]->point() + v[2]->point() + v[3]->point());
+            auto uv = gsurf.parameter_from_point(center_pt);
+
+            auto center_vtx = Ptr<MeshSurfaceVertex>::alloc(this->gsurface_, uv);
+            add_triangle({ v[0], v[1], center_vtx });
+            add_triangle({ v[1], v[2], center_vtx });
+            add_triangle({ v[2], v[3], center_vtx });
+            add_triangle({ v[3], v[0], center_vtx });
+        }
+    }
+    this->quads_.clear();
+}
+
+void
 MeshSurface::reserve_mem(std::size_t n_vtxs, std::size_t n_tris)
 {
     this->tris_.reserve(n_tris);

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -609,6 +609,19 @@ PYBIND11_MODULE(krado, m)
         .def("elements", &MeshSurface::elements)
         .def("remove_all_triangles", &MeshSurface::remove_all_triangles)
         .def("delete_mesh", &MeshSurface::delete_mesh)
+        .def("quads_to_tris", [](MeshSurface & self, py::kwargs kwargs) {
+                QuadSplitMode split = QuadSplitMode::SPLIT2;
+                if (kwargs.contains("split")) {
+                    auto n = kwargs["split"].cast<int>();
+                    if (n == 2)
+                        split = QuadSplitMode::SPLIT2;
+                    else if (n == 4)
+                        split = QuadSplitMode::SPLIT4;
+                    else
+                        throw Exception("Unsupported split");
+                }
+                self.quads_to_tris(split);
+            })
         .def("set_scheme",
              [](MeshSurface & self, const std::string & name, py::kwargs kwargs) {
                  if (name == "bamg") {

--- a/test/src/MeshSurface_test.cpp
+++ b/test/src/MeshSurface_test.cpp
@@ -68,3 +68,43 @@ TEST(MeshSurfaceTest, op_shl_rect)
     EXPECT_EQ(ss.str(),
               "Surface 1: curves=[1, 2, 3, 4], (u, v)=[-1.5, 1.5]x[-1.25, 1.25], area=7.5");
 }
+
+TEST(MeshSurfaceTest, quads_to_tris_2)
+{
+    auto rect = testing::build_rect(Point(0, 0, 0), Point(1, 1, 0));
+    GeomModel model(rect);
+    auto msurface = model.surface(1);
+
+    auto v0 = Ptr<MeshSurfaceVertex>::alloc(msurface->geom_surface(), 0., 0.);
+    auto v1 = Ptr<MeshSurfaceVertex>::alloc(msurface->geom_surface(), 1., 0.);
+    auto v2 = Ptr<MeshSurfaceVertex>::alloc(msurface->geom_surface(), 1., 1.);
+    auto v3 = Ptr<MeshSurfaceVertex>::alloc(msurface->geom_surface(), 0., 1.);
+    msurface->add_quadrangle({ v0, v1, v2, v3 });
+
+    EXPECT_EQ(msurface->quadrangles().size(), 1);
+    EXPECT_EQ(msurface->triangles().size(), 0);
+
+    msurface->quads_to_tris();
+    EXPECT_EQ(msurface->quadrangles().size(), 0);
+    EXPECT_EQ(msurface->triangles().size(), 2);
+}
+
+TEST(MeshSurfaceTest, quads_to_tris_4)
+{
+    auto rect = testing::build_rect(Point(0, 0, 0), Point(1, 1, 0));
+    GeomModel model(rect);
+    auto msurface = model.surface(1);
+
+    auto v0 = Ptr<MeshSurfaceVertex>::alloc(msurface->geom_surface(), 0., 0.);
+    auto v1 = Ptr<MeshSurfaceVertex>::alloc(msurface->geom_surface(), 1., 0.);
+    auto v2 = Ptr<MeshSurfaceVertex>::alloc(msurface->geom_surface(), 1., 1.);
+    auto v3 = Ptr<MeshSurfaceVertex>::alloc(msurface->geom_surface(), 0., 1.);
+    msurface->add_quadrangle({ v0, v1, v2, v3 });
+
+    EXPECT_EQ(msurface->quadrangles().size(), 1);
+    EXPECT_EQ(msurface->triangles().size(), 0);
+
+    msurface->quads_to_tris(QuadSplitMode::SPLIT4);
+    EXPECT_EQ(msurface->quadrangles().size(), 0);
+    EXPECT_EQ(msurface->triangles().size(), 4);
+}


### PR DESCRIPTION
Allows to split quads into 2 or 4 triangles
