### PR TITLE
Reworking `Size` scheme

### DIFF
--- a/lib/include/krado/range.h
+++ b/lib/include/krado/range.h
@@ -116,6 +116,25 @@ operator==(const Range & a, const Range & b)
     return (a.first() == b.first()) && (a.last() == b.last());
 }
 
+/// Create a range from `start` to `end`
+///
+/// @param start First element
+/// @param end Last elements (excluded)
+inline Range
+make_range(Index start, Index end)
+{
+    return Range(start, end);
+}
+
+/// Create a range from 0 to `end`
+///
+/// @param end Last elements (excluded)
+inline Range
+make_range(Index end)
+{
+    return Range(0, end);
+}
+
 } // namespace krado
 
 inline std::ostream &

--- a/lib/include/krado/scheme/integral.h
+++ b/lib/include/krado/scheme/integral.h
@@ -37,7 +37,7 @@ public:
     }
 
     std::size_t
-    num_point() const
+    num_points() const
     {
         return this->points_.size();
     }

--- a/lib/include/krado/scheme/integral.h
+++ b/lib/include/krado/scheme/integral.h
@@ -32,7 +32,7 @@ public:
         Pt from { t_lo, fn(t_lo), 0. };
         this->points_.push_back(from);
 
-        Pt to { t_hi, fn(t_lo), 0. };
+        Pt to { t_hi, fn(t_hi), 0. };
         recursive_integrate(from, to, fn, 0);
     }
 

--- a/lib/include/krado/scheme/integral.h
+++ b/lib/include/krado/scheme/integral.h
@@ -42,7 +42,7 @@ public:
         return this->points_.size();
     }
 
-    const Pt &
+    Pt
     point(std::size_t idx) const
     {
         return this->points_[idx];

--- a/lib/include/krado/scheme/size.h
+++ b/lib/include/krado/scheme/size.h
@@ -11,8 +11,8 @@ namespace krado {
 class SchemeSize : public Scheme1D {
 public:
     struct Options {
-        /// Number of intervals
-        int intervals = 1;
+        /// Approximate element size
+        double size = 1.;
     };
 
 public:

--- a/lib/src/scheme/bias.cpp
+++ b/lib/src/scheme/bias.cpp
@@ -38,8 +38,8 @@ SchemeBias::mesh_curve(Ptr<MeshCurve> curve)
     double l0 = geom_curve.length() * (bias_factor - 1.) / (std::pow(bias_factor, n_segs) - 1);
     double p_prev = 0.;
     for (int count = 1, num_pts = 0; num_pts < n_segs - 1;) {
-        auto & pt1 = igrl.point(count - 1);
-        auto & pt2 = igrl.point(count);
+        auto pt1 = igrl.point(count - 1);
+        auto pt2 = igrl.point(count);
         const auto d = p_prev + l0 * std::pow(bias_factor, num_pts);
         if ((std::abs(pt2.p) >= std::abs(d)) && (std::abs(pt1.p) < std::abs(d))) {
             p_prev = d;

--- a/lib/src/scheme/bias.cpp
+++ b/lib/src/scheme/bias.cpp
@@ -27,7 +27,6 @@ SchemeBias::mesh_curve(Ptr<MeshCurve> curve)
               n_segs,
               bias_factor);
 
-    // compute arc length
     Integral igrl;
     igrl.integrate(geom_curve, [=](double t) {
         auto der = geom_curve.d1(t);

--- a/lib/src/scheme/equal.cpp
+++ b/lib/src/scheme/equal.cpp
@@ -33,8 +33,8 @@ SchemeEqual::mesh_curve(Ptr<MeshCurve> curve)
 
     const double b = geom_curve.length() / static_cast<double>(n_segs);
     for (int count = 1, num_pts = 1; num_pts < n_segs;) {
-        auto & pt1 = igrl.point(count - 1);
-        auto & pt2 = igrl.point(count);
+        auto pt1 = igrl.point(count - 1);
+        auto pt2 = igrl.point(count);
         const auto d = (double) num_pts * b;
         if ((std::abs(pt2.p) >= std::abs(d)) && (std::abs(pt1.p) < std::abs(d))) {
             const auto dt = pt2.t - pt1.t;

--- a/lib/src/scheme/equal.cpp
+++ b/lib/src/scheme/equal.cpp
@@ -24,7 +24,6 @@ SchemeEqual::mesh_curve(Ptr<MeshCurve> curve)
 
     Log::info("Meshing curve {}: scheme='equal', intervals={}", curve->id(), n_segs);
 
-    // compute arc length
     Integral igrl;
     igrl.integrate(geom_curve, [=](double t) {
         auto der = geom_curve.d1(t);

--- a/lib/src/scheme/pinpoint.cpp
+++ b/lib/src/scheme/pinpoint.cpp
@@ -24,7 +24,6 @@ SchemePinpoint::mesh_curve(Ptr<MeshCurve> curve)
 
     Log::info("Meshing curve {}: scheme='pinpoint'", curve->id());
 
-    // compute arc length
     Integral igrl;
     igrl.integrate(geom_curve, [=](double t) {
         auto der = geom_curve.d1(t);

--- a/lib/src/scheme/pinpoint.cpp
+++ b/lib/src/scheme/pinpoint.cpp
@@ -34,8 +34,8 @@ SchemePinpoint::mesh_curve(Ptr<MeshCurve> curve)
     // place mesh curve vertices
     std::sort(apos.begin(), apos.end());
     for (std::size_t count = 1, num_pts = 0; num_pts < apos.size() && count < igrl.num_points();) {
-        auto & pt1 = igrl.point(count - 1);
-        auto & pt2 = igrl.point(count);
+        auto pt1 = igrl.point(count - 1);
+        auto pt2 = igrl.point(count);
         const auto d = apos[num_pts];
         if ((std::abs(pt1.p) < std::abs(d)) && (std::abs(d) <= std::abs(pt2.p))) {
             const auto dt = pt2.t - pt1.t;

--- a/lib/src/scheme/pinpoint.cpp
+++ b/lib/src/scheme/pinpoint.cpp
@@ -33,7 +33,7 @@ SchemePinpoint::mesh_curve(Ptr<MeshCurve> curve)
 
     // place mesh curve vertices
     std::sort(apos.begin(), apos.end());
-    for (std::size_t count = 1, num_pts = 0; num_pts < apos.size() && count < igrl.num_point();) {
+    for (std::size_t count = 1, num_pts = 0; num_pts < apos.size() && count < igrl.num_points();) {
         auto & pt1 = igrl.point(count - 1);
         auto & pt2 = igrl.point(count);
         const auto d = apos[num_pts];

--- a/lib/src/scheme/size.cpp
+++ b/lib/src/scheme/size.cpp
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 #include "krado/scheme/size.h"
+#include "krado/scheme/integral.h"
 #include "krado/mesh_vertex.h"
 #include "krado/mesh_curve.h"
 #include "krado/mesh_curve_vertex.h"
 #include "krado/geom_curve.h"
+#include "krado/vector.h"
 #include "krado/log.h"
 #include "krado/utils.h"
-#include "GCPnts_AbscissaPoint.hxx"
 
 namespace krado {
 
@@ -17,47 +18,32 @@ SchemeSize::SchemeSize(Options options) : Scheme1D("size"), opts_(options) {}
 void
 SchemeSize::mesh_curve(Ptr<MeshCurve> curve)
 {
-    Log::info("Meshing curve {}: scheme='size'", curve->id());
+    Log::info("Meshing curve {}: scheme='size', size={}", curve->id(), this->opts_.size);
 
     const auto & geom_curve = curve->geom_curve();
-    GeomAdaptor_Curve adaptor(geom_curve.curve_handle());
 
-    auto [t0, t1] = geom_curve.param_range();
-    const double tol = 1e-6;
+    Integral igrl;
+    igrl.integrate(geom_curve, [=](double t) {
+        auto der = geom_curve.d1(t);
+        return der.magnitude();
+    });
 
-    double total_length = GCPnts_AbscissaPoint::Length(adaptor, t0, t1, tol);
-    if (total_length < tol) {
-        Log::warn("Curve {} is too small (length={})", curve->id(), total_length);
-        curve->set_too_small(true);
-        return;
-    }
-
-    const auto & bnd_verts = curve->bounding_vertices();
-    if (bnd_verts.size() != 2)
-        throw Exception("Curve {} must have 2 bounding vertices", curve->id());
-
-    double s = 0.0;
-    double t = t0;
-    while (s < total_length - tol) {
-        auto u = t;
-        auto h = curve->mesh_size_at_param(u);
-
-        if (s + h > total_length)
-            h = total_length - s;
-
-        GCPnts_AbscissaPoint abscissa(adaptor, h, t, tol);
-        if (!abscissa.IsDone())
-            throw Exception("Failed to compute abscissa point");
-
-        t = abscissa.Parameter();
-        if (t < t1 - tol) {
-            auto cvtx = Ptr<MeshCurveVertex>::alloc(geom_curve, t);
-            curve->add_vertex(cvtx);
-            s += h;
+    int n_segs = std::round(geom_curve.length() / this->opts_.size);
+    const double b = geom_curve.length() / static_cast<double>(n_segs);
+    for (int count = 1, num_pts = 1; num_pts < n_segs;) {
+        auto pt1 = igrl.point(count - 1);
+        auto pt2 = igrl.point(count);
+        const double d = num_pts * b;
+        if ((std::abs(pt2.p) >= std::abs(d)) && (std::abs(pt1.p) < std::abs(d))) {
+            const auto dt = pt2.t - pt1.t;
+            const auto dp = pt2.p - pt1.p;
+            const auto t = pt1.t + dt / dp * (d - pt1.p);
+            curve->add_vertex(Ptr<MeshCurveVertex>::alloc(geom_curve, t));
+            num_pts++;
         }
-        else
-            // Reached (or passed) end parameter
-            break;
+        else {
+            count++;
+        }
     }
 
     build_curve_segments(curve);

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -607,8 +607,8 @@ PYBIND11_MODULE(krado, m)
                  }
                  else if (name == "size") {
                      SchemeSize::Options opts;
-                     if (kwargs.contains("intervals"))
-                         opts.intervals = kwargs["intervals"].cast<int>();
+                     if (kwargs.contains("size"))
+                         opts.size = kwargs["size"].cast<double>();
                      self.set_scheme<SchemeSize>(opts);
                  }
              },

--- a/test/src/Integral_test.cpp
+++ b/test/src/Integral_test.cpp
@@ -1,0 +1,38 @@
+#include <gmock/gmock.h>
+#include "builder.h"
+#include "krado/scheme/integral.h"
+#include "krado/geom_curve.h"
+#include "krado/vector.h"
+
+using namespace krado;
+
+TEST(IntegralTest, line)
+{
+    auto line = testing::build_line(Point(0, 0, 0), Point(3, 4, 0));
+
+    auto lc = [](double t) {
+        // this matches the line parameter
+        const double lo = 0.;
+        const double hi = 5.;
+        const double lc_lo = 0.1;
+        const double lc_hi = 0.5;
+        return lc_lo + (t - lo) * (lc_hi - lc_lo) / (hi - lo);
+    };
+
+    Integral igrl;
+    igrl.integrate(line, [=](double t) {
+        auto der = line.d1(t);
+        return der.magnitude() / lc(t);
+    });
+
+    ASSERT_EQ(igrl.num_points(), 2467);
+    auto pt0 = igrl.point(0);
+    EXPECT_NEAR(pt0.t, 0., 1e-15);
+    EXPECT_NEAR(pt0.lc, 10., 1e-15);
+    EXPECT_NEAR(pt0.p, 0., 1e-15);
+
+    auto pt1 = igrl.point(2466);
+    EXPECT_NEAR(pt1.t, 5., 1e-15);
+    EXPECT_NEAR(pt1.lc, 2., 1e-15);
+    EXPECT_NEAR(pt1.p, 20.118, 1e-3);
+}

--- a/test/src/Range_test.cpp
+++ b/test/src/Range_test.cpp
@@ -1,0 +1,26 @@
+#include <gmock/gmock.h>
+#include "krado/range.h"
+
+using namespace krado;
+
+TEST(RangeTest, test)
+{
+    Range rng(2, 10);
+    EXPECT_EQ(rng.first(), 2);
+    EXPECT_EQ(rng.last(), 10);
+    EXPECT_EQ(rng.size(), 8);
+}
+
+TEST(RangeTest, make_range_1)
+{
+    auto rng = make_range(7);
+    EXPECT_EQ(rng.first(), 0);
+    EXPECT_EQ(rng.last(), 7);
+}
+
+TEST(RangeTest, make_range_2)
+{
+    auto rng = make_range(2, 7);
+    EXPECT_EQ(rng.first(), 2);
+    EXPECT_EQ(rng.last(), 7);
+}

--- a/test/src/SchemeIntegral_test.cpp
+++ b/test/src/SchemeIntegral_test.cpp
@@ -16,7 +16,7 @@ TEST(SchemeIntegralTest, arc_length_of_a_line)
         return der.magnitude();
     });
 
-    EXPECT_EQ(igrl.num_point(), 257);
+    EXPECT_EQ(igrl.num_points(), 257);
 
     auto lo = igrl.point(0);
     EXPECT_NEAR(lo.t, 0, 1e-15);
@@ -38,7 +38,7 @@ TEST(SchemeIntegralTest, arc_length_of_an_arc)
         return der.magnitude();
     });
 
-    EXPECT_EQ(igrl.num_point(), 257);
+    EXPECT_EQ(igrl.num_points(), 257);
 
     auto lo = igrl.point(0);
     EXPECT_NEAR(lo.t, 0, 1e-15);

--- a/test/src/SchemeSize_test.cpp
+++ b/test/src/SchemeSize_test.cpp
@@ -9,15 +9,13 @@
 
 using namespace krado;
 
-TEST(SchemeSizeTest, line_with_vertex_sizes)
+TEST(SchemeSizeTest, line_0_3)
 {
     auto shape = testing::build_line(Point(0, 0, 0), Point(1, 0, 0));
     GeomModel model(shape);
 
-    model.vertex(1)->set_mesh_size(0.3);
-    model.vertex(2)->set_mesh_size(0.2);
-
     SchemeSize::Options opts;
+    opts.size = 0.3;
     model.curve(1)->set_scheme<SchemeSize>(opts);
     model.mesh_curve(1);
 
@@ -28,10 +26,37 @@ TEST(SchemeSizeTest, line_with_vertex_sizes)
     EXPECT_TRUE(bv[1]->point().is_equal(Point(1, 0, 0), 1e-10));
 
     auto cv = line->curve_vertices();
-    ASSERT_EQ(cv.size(), 3);
-    EXPECT_TRUE(cv[0]->point().is_equal(Point(0.3, 0, 0), 1e-8));
-    EXPECT_TRUE(cv[1]->point().is_equal(Point(0.57, 0, 0), 1e-8));
-    EXPECT_TRUE(cv[2]->point().is_equal(Point(0.813, 0, 0), 1e-8));
+    ASSERT_EQ(cv.size(), 2);
+    EXPECT_TRUE(cv[0]->point().is_equal(Point(0.333333, 0, 0), 1e-5));
+    EXPECT_TRUE(cv[1]->point().is_equal(Point(0.666666, 0, 0), 1e-5));
 
-    ASSERT_EQ(line->segments().size(), 4);
+    ASSERT_EQ(line->segments().size(), 3);
+}
+
+TEST(SchemeSizeTest, line_0_15)
+{
+    auto shape = testing::build_line(Point(0, 0, 0), Point(1, 0, 0));
+    GeomModel model(shape);
+
+    SchemeSize::Options opts;
+    opts.size = 0.15;
+    model.curve(1)->set_scheme<SchemeSize>(opts);
+    model.mesh_curve(1);
+
+    auto line = model.curve(1);
+    auto bv = line->bounding_vertices();
+    ASSERT_EQ(bv.size(), 2);
+    EXPECT_TRUE(bv[0]->point().is_equal(Point(0, 0, 0), 1e-10));
+    EXPECT_TRUE(bv[1]->point().is_equal(Point(1, 0, 0), 1e-10));
+
+    auto cv = line->curve_vertices();
+    ASSERT_EQ(cv.size(), 6);
+    EXPECT_TRUE(cv[0]->point().is_equal(Point(0.142857, 0, 0), 1e-5));
+    EXPECT_TRUE(cv[1]->point().is_equal(Point(0.285714, 0, 0), 1e-5));
+    EXPECT_TRUE(cv[2]->point().is_equal(Point(0.428571, 0, 0), 1e-5));
+    EXPECT_TRUE(cv[3]->point().is_equal(Point(0.571429, 0, 0), 1e-5));
+    EXPECT_TRUE(cv[4]->point().is_equal(Point(0.714286, 0, 0), 1e-5));
+    EXPECT_TRUE(cv[5]->point().is_equal(Point(0.857143, 0, 0), 1e-5));
+
+    ASSERT_EQ(line->segments().size(), 7);
 }


### PR DESCRIPTION
- users specify element size
- it is approximate size for all line segments
- it ignores:
  * mesh size in bounding vertices
  * mesh size specified on the curve
