### PR TITLE
Redoing API in schemes

### DIFF
--- a/lib/include/krado/scheme/bamg.h
+++ b/lib/include/krado/scheme/bamg.h
@@ -17,9 +17,10 @@ public:
 
 public:
     SchemeBAMG(Options options);
-    void mesh_surface(Ptr<MeshSurface> surface) override;
 
 private:
+    void on_mesh_surface(Ptr<MeshSurface> surface) override;
+
     Options opts_;
 };
 

--- a/lib/include/krado/scheme/bias.h
+++ b/lib/include/krado/scheme/bias.h
@@ -17,9 +17,10 @@ public:
 
 public:
     SchemeBias(Options options);
-    void mesh_curve(Ptr<MeshCurve> surface) override;
 
 private:
+    void on_mesh_curve(Ptr<MeshCurve> surface) override;
+
     Options opts_;
 };
 

--- a/lib/include/krado/scheme/curvature.h
+++ b/lib/include/krado/scheme/curvature.h
@@ -22,9 +22,10 @@ public:
 
 public:
     SchemeCurvature(Options options);
-    void mesh_curve(Ptr<MeshCurve> mcurve) override;
 
 private:
+    void on_mesh_curve(Ptr<MeshCurve> mcurve) override;
+
     Options opts_;
 };
 

--- a/lib/include/krado/scheme/equal.h
+++ b/lib/include/krado/scheme/equal.h
@@ -16,9 +16,10 @@ public:
 
 public:
     SchemeEqual(Options options);
-    void mesh_curve(Ptr<MeshCurve> surface) override;
 
 private:
+    void on_mesh_curve(Ptr<MeshCurve> surface) override;
+
     Options opts_;
 };
 

--- a/lib/include/krado/scheme/fan.h
+++ b/lib/include/krado/scheme/fan.h
@@ -27,9 +27,8 @@ public:
 public:
     SchemeFan(Options options);
 
-    void mesh_surface(Ptr<MeshSurface> surface) override;
-
 private:
+    void on_mesh_surface(Ptr<MeshSurface> surface) override;
 };
 
 } // namespace krado

--- a/lib/include/krado/scheme/pinpoint.h
+++ b/lib/include/krado/scheme/pinpoint.h
@@ -17,9 +17,10 @@ public:
 
 public:
     SchemePinpoint(Options options);
-    void mesh_curve(Ptr<MeshCurve> surface) override;
 
 private:
+    void on_mesh_curve(Ptr<MeshCurve> surface) override;
+
     Options opts_;
 };
 

--- a/lib/include/krado/scheme/size.h
+++ b/lib/include/krado/scheme/size.h
@@ -17,9 +17,10 @@ public:
 
 public:
     SchemeSize(Options options);
-    void mesh_curve(Ptr<MeshCurve> surface) override;
 
 private:
+    void on_mesh_curve(Ptr<MeshCurve> surface) override;
+
     Options opts_;
 };
 

--- a/lib/include/krado/scheme/structured.h
+++ b/lib/include/krado/scheme/structured.h
@@ -16,9 +16,9 @@ public:
 
 public:
     SchemeStructured(Options options);
-    void mesh_surface(Ptr<MeshSurface> surface) override;
 
 private:
+    void on_mesh_surface(Ptr<MeshSurface> surface) override;
 };
 
 } // namespace krado

--- a/lib/include/krado/scheme/tricircle.h
+++ b/lib/include/krado/scheme/tricircle.h
@@ -21,10 +21,10 @@ public:
 public:
     SchemeTriCircle(Options options);
 
-    void mesh_surface(Ptr<MeshSurface> surface) override;
-    void select_curve_scheme(Ptr<MeshCurve> curve) override;
-
 private:
+    void on_mesh_surface(Ptr<MeshSurface> surface) override;
+    void on_select_curve_scheme(Ptr<MeshCurve> curve) override;
+
     Options opts_;
 };
 

--- a/lib/include/krado/scheme/trisurf.h
+++ b/lib/include/krado/scheme/trisurf.h
@@ -24,14 +24,15 @@ public:
 
 public:
     SchemeTriSurf(Options options);
-    void mesh_volume(Ptr<MeshVolume> volume) override;
-    void mesh_surface(Ptr<MeshSurface> surface) override;
-    void mesh_curve(Ptr<MeshCurve> mcurve) override;
-
-    void select_surface_scheme(Ptr<MeshSurface> surface) override;
-    void select_curve_scheme(Ptr<MeshCurve> curve) override;
 
 private:
+    void on_mesh_volume(Ptr<MeshVolume> volume) override;
+    void on_mesh_surface(Ptr<MeshSurface> surface) override;
+    void on_mesh_curve(Ptr<MeshCurve> mcurve) override;
+
+    void on_select_surface_scheme(Ptr<MeshSurface> surface) override;
+    void on_select_curve_scheme(Ptr<MeshCurve> curve) override;
+
     Options opts_;
 };
 

--- a/lib/include/krado/scheme1d.h
+++ b/lib/include/krado/scheme1d.h
@@ -14,7 +14,8 @@ class Scheme1D {
 public:
     Scheme1D(const std::string & name) : name_(name) {}
     virtual ~Scheme1D() = default;
-    virtual void mesh_curve(Ptr<MeshCurve> mcurve) = 0;
+
+    void mesh_curve(Ptr<MeshCurve> mcurve);
 
     const std::string
     name() const
@@ -23,6 +24,8 @@ public:
     }
 
 protected:
+    virtual void on_mesh_curve(Ptr<MeshCurve> mcurve) = 0;
+
     /// Build segments for a curve
     ///
     /// @param curve Mesh curve

--- a/lib/include/krado/scheme2d.h
+++ b/lib/include/krado/scheme2d.h
@@ -19,12 +19,12 @@ public:
     /// Mesh surface
     ///
     /// @param surface Surface to mesh
-    virtual void mesh_surface(Ptr<MeshSurface> surface) = 0;
+    void mesh_surface(Ptr<MeshSurface> surface);
 
     /// Select meshing scheme for a curve
     ///
     /// @param curve Curve to select the scheme for
-    virtual void select_curve_scheme(Ptr<MeshCurve> curve);
+    void select_curve_scheme(Ptr<MeshCurve> curve);
 
     const std::string
     name() const
@@ -33,6 +33,16 @@ public:
     }
 
 private:
+    /// Mesh surface
+    ///
+    /// @param surface Surface to mesh
+    virtual void on_mesh_surface(Ptr<MeshSurface> surface) = 0;
+
+    /// Select meshing scheme for a curve
+    ///
+    /// @param curve Curve to select the scheme for
+    virtual void on_select_curve_scheme(Ptr<MeshCurve> curve);
+
     std::string name_;
 };
 

--- a/lib/include/krado/scheme3d.h
+++ b/lib/include/krado/scheme3d.h
@@ -19,12 +19,12 @@ public:
     /// Mesh a volume
     ///
     /// @param volume Volume to mesh
-    virtual void mesh_volume(Ptr<MeshVolume> volume) = 0;
+    void mesh_volume(Ptr<MeshVolume> volume);
 
     /// Select meshing scheme for a surface
     ///
     /// @param surface Surface to mesh
-    virtual void select_surface_scheme(Ptr<MeshSurface> surface);
+    void select_surface_scheme(Ptr<MeshSurface> surface);
 
     const std::string
     name() const
@@ -33,6 +33,16 @@ public:
     }
 
 private:
+    /// Mesh a volume
+    ///
+    /// @param volume Volume to mesh
+    virtual void on_mesh_volume(Ptr<MeshVolume> volume) = 0;
+
+    /// Select meshing scheme for a surface
+    ///
+    /// @param surface Surface to mesh
+    virtual void on_select_surface_scheme(Ptr<MeshSurface> surface);
+
     std::string name_;
 };
 

--- a/lib/src/scheme/bamg.cpp
+++ b/lib/src/scheme/bamg.cpp
@@ -8,7 +8,6 @@
 #include "krado/mesh_curve_vertex.h"
 #include "krado/mesh_surface.h"
 #include "krado/surface_index_mapper.h"
-#include "krado/log.h"
 #include "bamg/bamglib/Mesh2.h"
 #include "Eigen/Eigen"
 #include <array>
@@ -249,10 +248,8 @@ private:
 SchemeBAMG::SchemeBAMG(Options options) : Scheme2D("bamg"), opts_(options) {}
 
 void
-SchemeBAMG::mesh_surface(Ptr<MeshSurface> surface)
+SchemeBAMG::on_mesh_surface(Ptr<MeshSurface> surface)
 {
-    Log::info("Meshing surface {}: scheme='bamg'", surface->id());
-
     BAMGSession bamg_session(surface);
     bamg_session.set_uniform_mesh_size(this->opts_.max_area);
 

--- a/lib/src/scheme/bias.cpp
+++ b/lib/src/scheme/bias.cpp
@@ -8,7 +8,6 @@
 #include "krado/mesh_curve_vertex.h"
 #include "krado/geom_curve.h"
 #include "krado/vector.h"
-#include "krado/log.h"
 #include "krado/utils.h"
 
 namespace krado {
@@ -16,16 +15,11 @@ namespace krado {
 SchemeBias::SchemeBias(Options options) : Scheme1D("bias"), opts_(options) {}
 
 void
-SchemeBias::mesh_curve(Ptr<MeshCurve> curve)
+SchemeBias::on_mesh_curve(Ptr<MeshCurve> curve)
 {
     auto & geom_curve = curve->geom_curve();
     auto n_segs = this->opts_.intervals;
     auto bias_factor = this->opts_.factor;
-
-    Log::info("Meshing curve {}: scheme='bias', intervals={}, bias={}",
-              curve->id(),
-              n_segs,
-              bias_factor);
 
     Integral igrl;
     igrl.integrate(geom_curve, [=](double t) {

--- a/lib/src/scheme/curvature.cpp
+++ b/lib/src/scheme/curvature.cpp
@@ -17,14 +17,8 @@ namespace krado {
 SchemeCurvature::SchemeCurvature(Options options) : Scheme1D("curvature"), opts_(options) {}
 
 void
-SchemeCurvature::mesh_curve(Ptr<MeshCurve> curve)
+SchemeCurvature::on_mesh_curve(Ptr<MeshCurve> curve)
 {
-    Log::info("Meshing curve {}: scheme='curvature', min_size={}, max_size={}, deflection={}",
-              curve->id(),
-              this->opts_.min_size,
-              this->opts_.max_size,
-              this->opts_.deflection);
-
     const auto & geom_curve = curve->geom_curve();
     GeomAdaptor_Curve adaptor(geom_curve.curve_handle());
 

--- a/lib/src/scheme/equal.cpp
+++ b/lib/src/scheme/equal.cpp
@@ -8,7 +8,6 @@
 #include "krado/mesh_curve_vertex.h"
 #include "krado/geom_curve.h"
 #include "krado/vector.h"
-#include "krado/log.h"
 #include "krado/ptr.h"
 #include "krado/utils.h"
 
@@ -17,12 +16,10 @@ namespace krado {
 SchemeEqual::SchemeEqual(Options options) : Scheme1D("equal"), opts_(options) {}
 
 void
-SchemeEqual::mesh_curve(Ptr<MeshCurve> curve)
+SchemeEqual::on_mesh_curve(Ptr<MeshCurve> curve)
 {
     auto & geom_curve = curve->geom_curve();
     auto n_segs = this->opts_.intervals;
-
-    Log::info("Meshing curve {}: scheme='equal', intervals={}", curve->id(), n_segs);
 
     Integral igrl;
     igrl.integrate(geom_curve, [=](double t) {

--- a/lib/src/scheme/fan.cpp
+++ b/lib/src/scheme/fan.cpp
@@ -11,7 +11,6 @@
 #include "krado/mesh_curve_vertex.h"
 #include "krado/mesh_surface.h"
 #include "krado/mesh_surface_vertex.h"
-#include "krado/log.h"
 #include "krado/utils.h"
 #include "krado/element.h"
 #include "krado/vector.h"
@@ -44,10 +43,8 @@ find_shared_vertex(Ptr<MeshCurve> crv1, Ptr<MeshCurve> crv2)
 SchemeFan::SchemeFan(Options /*options*/) : Scheme2D(scheme_name) {}
 
 void
-SchemeFan::mesh_surface(Ptr<MeshSurface> mesh_surface)
+SchemeFan::on_mesh_surface(Ptr<MeshSurface> mesh_surface)
 {
-    Log::info("Meshing surface {}: scheme='fan'", mesh_surface->id());
-
     const auto & gsurf = mesh_surface->geom_surface();
     auto curves = mesh_surface->curves();
     if (curves.size() != 3)
@@ -250,8 +247,6 @@ SchemeFan::mesh_surface(Ptr<MeshSurface> mesh_surface)
         for (auto v : make_range(outer.size() - 1))
             mesh_surface->add_triangle(ccw_triangle(gsurf, outer[v], outer[v + 1], center_vtx));
     }
-
-    Log::info("- generated {} triangles", utils::human_number(mesh_surface->triangles().size()));
 }
 
 } // namespace krado

--- a/lib/src/scheme/pinpoint.cpp
+++ b/lib/src/scheme/pinpoint.cpp
@@ -8,7 +8,6 @@
 #include "krado/mesh_curve_vertex.h"
 #include "krado/geom_curve.h"
 #include "krado/vector.h"
-#include "krado/log.h"
 #include "krado/utils.h"
 #include <algorithm>
 
@@ -17,12 +16,10 @@ namespace krado {
 SchemePinpoint::SchemePinpoint(Options options) : Scheme1D("pinpoint"), opts_(options) {}
 
 void
-SchemePinpoint::mesh_curve(Ptr<MeshCurve> curve)
+SchemePinpoint::on_mesh_curve(Ptr<MeshCurve> curve)
 {
     auto & geom_curve = curve->geom_curve();
     auto apos = this->opts_.positions;
-
-    Log::info("Meshing curve {}: scheme='pinpoint'", curve->id());
 
     Integral igrl;
     igrl.integrate(geom_curve, [=](double t) {

--- a/lib/src/scheme/size.cpp
+++ b/lib/src/scheme/size.cpp
@@ -16,10 +16,8 @@ namespace krado {
 SchemeSize::SchemeSize(Options options) : Scheme1D("size"), opts_(options) {}
 
 void
-SchemeSize::mesh_curve(Ptr<MeshCurve> curve)
+SchemeSize::on_mesh_curve(Ptr<MeshCurve> curve)
 {
-    Log::info("Meshing curve {}: scheme='size', size={}", curve->id(), this->opts_.size);
-
     const auto & geom_curve = curve->geom_curve();
 
     Integral igrl;

--- a/lib/src/scheme/structured.cpp
+++ b/lib/src/scheme/structured.cpp
@@ -12,7 +12,6 @@
 #include "krado/mesh_surface_vertex.h"
 #include "krado/mesh_vertex_abstract.h"
 #include "krado/exception.h"
-#include "krado/log.h"
 #include "krado/utils.h"
 #include "krado/range.h"
 #include <vector>
@@ -79,10 +78,8 @@ sort_curves(Span<Ptr<MeshCurve>> curves)
 SchemeStructured::SchemeStructured(Options /*options*/) : Scheme2D("structured") {}
 
 void
-SchemeStructured::mesh_surface(Ptr<MeshSurface> surface)
+SchemeStructured::on_mesh_surface(Ptr<MeshSurface> surface)
 {
-    Log::info("Meshing surface {}: scheme='structured'", surface->id());
-
     auto curves = surface->curves();
     if (curves.size() != 4)
         throw Exception("Scheme 'structured' only meshes geometries with 4 curves");

--- a/lib/src/scheme/tricircle.cpp
+++ b/lib/src/scheme/tricircle.cpp
@@ -13,7 +13,6 @@
 #include "krado/mesh_surface_vertex.h"
 #include "krado/scheme/equal.h"
 #include "krado/vector.h"
-#include "krado/log.h"
 #include "krado/utils.h"
 #include "krado/range.h"
 
@@ -24,7 +23,7 @@ static const std::string scheme_name = "tricircle";
 SchemeTriCircle::SchemeTriCircle(Options options) : Scheme2D(scheme_name), opts_(options) {}
 
 void
-SchemeTriCircle::select_curve_scheme(Ptr<MeshCurve> curve)
+SchemeTriCircle::on_select_curve_scheme(Ptr<MeshCurve> curve)
 {
     if (!curve->has_scheme()) {
         // minimum of 4 intervals
@@ -35,10 +34,8 @@ SchemeTriCircle::select_curve_scheme(Ptr<MeshCurve> curve)
 }
 
 void
-SchemeTriCircle::mesh_surface(Ptr<MeshSurface> mesh_surface)
+SchemeTriCircle::on_mesh_surface(Ptr<MeshSurface> mesh_surface)
 {
-    Log::info("Meshing surface {}: scheme='tricircle'", mesh_surface->id());
-
     const auto & gsurf = mesh_surface->geom_surface();
     if (!is_circular_face(gsurf))
         throw Exception("Surface {} is not a circle", mesh_surface->id());

--- a/lib/src/scheme/trisurf.cpp
+++ b/lib/src/scheme/trisurf.cpp
@@ -78,7 +78,7 @@ SchemeTriSurf::on_mesh_volume(Ptr<MeshVolume> volume)
                     cache.emplace(cv->parameter(), cv);
             }
 
-            for (auto j : make_range(polygon->NbNodes())) {
+            for (int j : make_range(polygon->NbNodes())) {
                 auto idx = polygon->Node(j + 1);
                 Ptr<MeshVertexAbstract> vtx;
                 if (j == 0) {

--- a/lib/src/scheme/trisurf.cpp
+++ b/lib/src/scheme/trisurf.cpp
@@ -9,7 +9,6 @@
 #include "krado/mesh_curve.h"
 #include "krado/mesh_curve_vertex.h"
 #include "krado/mesh_surface_vertex.h"
-#include "krado/log.h"
 #include "krado/geom_curve.h"
 #include "krado/geom_surface.h"
 #include "krado/geom_volume.h"
@@ -36,10 +35,8 @@ SchemeTriSurf::SchemeTriSurf(Options options) :
 }
 
 void
-SchemeTriSurf::mesh_volume(Ptr<MeshVolume> volume)
+SchemeTriSurf::on_mesh_volume(Ptr<MeshVolume> volume)
 {
-    Log::info("Meshing volume {}: scheme='trisurf'", volume->id());
-
     auto lin_deflection = this->opts_.linear_deflection;
     auto angl_deflection = this->opts_.angular_deflection;
     auto is_relative = this->opts_.is_relative;
@@ -133,19 +130,19 @@ SchemeTriSurf::mesh_volume(Ptr<MeshVolume> volume)
 }
 
 void
-SchemeTriSurf::mesh_surface(Ptr<MeshSurface> /*surface*/)
+SchemeTriSurf::on_mesh_surface(Ptr<MeshSurface> /*surface*/)
 {
     // do nothing
 }
 
 void
-SchemeTriSurf::mesh_curve(Ptr<MeshCurve> /*mcurve*/)
+SchemeTriSurf::on_mesh_curve(Ptr<MeshCurve> /*mcurve*/)
 {
     // do nothing
 }
 
 void
-SchemeTriSurf::select_surface_scheme(Ptr<MeshSurface> surface)
+SchemeTriSurf::on_select_surface_scheme(Ptr<MeshSurface> surface)
 {
     if (!surface->has_scheme())
         surface->set_scheme<SchemeTriSurf>(this->opts_);
@@ -159,7 +156,7 @@ SchemeTriSurf::select_surface_scheme(Ptr<MeshSurface> surface)
 }
 
 void
-SchemeTriSurf::select_curve_scheme(Ptr<MeshCurve> curve)
+SchemeTriSurf::on_select_curve_scheme(Ptr<MeshCurve> curve)
 {
     if (!curve->has_scheme()) {
         curve->set_scheme<SchemeTriSurf>(this->opts_);

--- a/lib/src/scheme1d.cpp
+++ b/lib/src/scheme1d.cpp
@@ -9,8 +9,18 @@
 #include "krado/mesh_curve_vertex.h"
 #include "krado/ptr.h"
 #include "krado/range.h"
+#include "krado/log.h"
+#include "krado/utils.h"
 
 namespace krado {
+
+void
+Scheme1D::mesh_curve(Ptr<MeshCurve> mcurve)
+{
+    Log::info("Meshing curve {}: scheme='{}'", mcurve->id(), name());
+    on_mesh_curve(mcurve);
+    Log::info("- created {} segment(s)", utils::human_number(mcurve->segments().size()));
+}
 
 void
 Scheme1D::build_curve_segments(Ptr<MeshCurve> curve)

--- a/lib/src/scheme2d.cpp
+++ b/lib/src/scheme2d.cpp
@@ -4,16 +4,35 @@
 #include "krado/scheme2d.h"
 #include "krado/mesh_curve.h"
 #include "krado/log.h"
+#include "krado/utils.h"
+#include "krado/mesh_surface.h"
 #include "krado/scheme/equal.h"
 
 namespace krado {
 
 void
+Scheme2D::mesh_surface(Ptr<MeshSurface> surface)
+{
+    Log::info("Meshing surface {}: scheme='{}'", surface->id(), name());
+    on_mesh_surface(surface);
+
+    if (surface->triangles().size() > 0)
+        Log::info("- created {} triangles(s)", utils::human_number(surface->triangles().size()));
+    if (surface->quadrangles().size() > 0)
+        Log::info("- created {} quadrangles(s)",
+                  utils::human_number(surface->quadrangles().size()));
+}
+
+void
 Scheme2D::select_curve_scheme(Ptr<MeshCurve> curve)
 {
-    if (!curve->has_scheme()) {
-        Log::info("Selecting curve scheme 'equal' for curve {}", curve->id());
+    on_select_curve_scheme(curve);
+}
 
+void
+Scheme2D::on_select_curve_scheme(Ptr<MeshCurve> curve)
+{
+    if (!curve->has_scheme()) {
         SchemeEqual::Options opt;
         opt.intervals = 1;
         curve->set_scheme<SchemeEqual>(opt);

--- a/lib/src/scheme3d.cpp
+++ b/lib/src/scheme3d.cpp
@@ -3,11 +3,26 @@
 
 #include "krado/scheme3d.h"
 #include "krado/mesh_surface.h"
+#include "krado/mesh_volume.h"
+#include "krado/log.h"
 
 namespace krado {
 
 void
-Scheme3D::select_surface_scheme(Ptr<MeshSurface> /*surface*/)
+Scheme3D::mesh_volume(Ptr<MeshVolume> volume)
+{
+    Log::info("Meshing volume {}: scheme='{}'", volume->id(), name());
+    on_mesh_volume(volume);
+}
+
+void
+Scheme3D::select_surface_scheme(Ptr<MeshSurface> surface)
+{
+    on_select_surface_scheme(surface);
+}
+
+void
+Scheme3D::on_select_surface_scheme(Ptr<MeshSurface> /*surface*/)
 {
 }
 


### PR DESCRIPTION
- `mesh_{curve|surface|volume}` are no longer virtuals
- added `on_mesh_{curve|surface|volume}` are virtual and have the
  original content of `mesh_{curve|surface|volume}` minus logging
- logging is done in `mesh_{curve|surface|volume}` so we get that
  consistently across all schemes
- the same for `select_{curve|surface|volume}`
