### PR TITLE
Adding timing capability

### DIFF
--- a/lib/include/krado/timer.h
+++ b/lib/include/krado/timer.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "krado/log.h"
+#include "krado/utils.h"
+#include <chrono>
+
+namespace krado {
+
+class LoggingTimer {
+public:
+    explicit LoggingTimer() : start_time_(std::chrono::steady_clock::now()) {}
+
+    // Destructor calculates and prints the elapsed time automatically
+    ~LoggingTimer()
+    {
+        auto end_time = std::chrono::steady_clock::now();
+
+        std::chrono::duration<double> elapsed_seconds = end_time - this->start_time_;
+        Log::info("- took {}", utils::human_time(elapsed_seconds.count()));
+    }
+
+    // Prevent copying to avoid duplicate timing logs
+    LoggingTimer(const LoggingTimer &) = delete;
+    LoggingTimer & operator=(const LoggingTimer &) = delete;
+
+    // Allow moving to transfer ownership of the timer
+    LoggingTimer(LoggingTimer &&) noexcept = default;
+    LoggingTimer & operator=(LoggingTimer &&) noexcept = default;
+
+private:
+    std::chrono::time_point<std::chrono::steady_clock> start_time_;
+};
+
+} // namespace krado

--- a/lib/include/krado/timer.h
+++ b/lib/include/krado/timer.h
@@ -9,7 +9,13 @@ namespace krado {
 
 class LoggingTimer {
 public:
-    explicit LoggingTimer() : start_time_(std::chrono::steady_clock::now()) {}
+    explicit LoggingTimer() : msg_("- took {}"), start_time_(std::chrono::steady_clock::now()) {}
+
+    explicit LoggingTimer(std::string fmt) :
+        msg_(fmt),
+        start_time_(std::chrono::steady_clock::now())
+    {
+    }
 
     // Destructor calculates and prints the elapsed time automatically
     ~LoggingTimer()
@@ -17,7 +23,7 @@ public:
         auto end_time = std::chrono::steady_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = end_time - this->start_time_;
-        Log::info("- took {}", utils::human_time(elapsed_seconds.count()));
+        Log::info(fmt::runtime(this->msg_), utils::human_time(elapsed_seconds.count()));
     }
 
     // Prevent copying to avoid duplicate timing logs
@@ -29,6 +35,7 @@ public:
     LoggingTimer & operator=(LoggingTimer &&) noexcept = default;
 
 private:
+    std::string msg_;
     std::chrono::time_point<std::chrono::steady_clock> start_time_;
 };
 

--- a/lib/include/krado/utils.h
+++ b/lib/include/krado/utils.h
@@ -221,6 +221,12 @@ human_number(T value)
     return result;
 }
 
+/// Print time duration in human readable form
+///
+/// @param time Duration
+/// @return Formatted string `1h 2m 1.2s` or `100.2ms` (for short time durations)
+std::string human_time(double time);
+
 /// Mark for unreachable code
 ///
 /// This is defined as `std::unreachable` in C++23, so we need this ATM.

--- a/lib/src/exodusii_file.cpp
+++ b/lib/src/exodusii_file.cpp
@@ -14,6 +14,7 @@
 #include "krado/mesh_surface.h"
 #include "krado/mesh_surface_vertex.h"
 #include "krado/mesh_volume.h"
+#include "krado/timer.h"
 #include "fmt/format.h"
 #include "fmt/chrono.h"
 
@@ -958,6 +959,7 @@ Mesh
 ExodusIIFile::read()
 {
     Log::info("Reading ExodusII file '{}'", this->fn_);
+    LoggingTimer timer;
 
     this->exo_.open(this->fn_);
     this->exo_.init();
@@ -1011,6 +1013,7 @@ void
 ExodusIIFile::write(const Mesh & mesh)
 {
     Log::info("Writing ExodusII file '{}'", this->fn_);
+    LoggingTimer timer;
 
     this->exo_.create(this->fn_);
     auto bbox = compute_bounding_box(mesh);
@@ -1040,6 +1043,7 @@ void
 ExodusIIFile::write(const GeomModel & model)
 {
     Log::info("Writing ExodusII file '{}'", this->fn_);
+    LoggingTimer timer;
 
     this->exo_.create(this->fn_);
 

--- a/lib/src/scheme1d.cpp
+++ b/lib/src/scheme1d.cpp
@@ -11,6 +11,7 @@
 #include "krado/range.h"
 #include "krado/log.h"
 #include "krado/utils.h"
+#include "krado/timer.h"
 
 namespace krado {
 
@@ -18,7 +19,10 @@ void
 Scheme1D::mesh_curve(Ptr<MeshCurve> mcurve)
 {
     Log::info("Meshing curve {}: scheme='{}'", mcurve->id(), name());
-    on_mesh_curve(mcurve);
+    {
+        LoggingTimer timer;
+        on_mesh_curve(mcurve);
+    }
     Log::info("- created {} segment(s)", utils::human_number(mcurve->segments().size()));
 }
 

--- a/lib/src/scheme2d.cpp
+++ b/lib/src/scheme2d.cpp
@@ -5,6 +5,7 @@
 #include "krado/mesh_curve.h"
 #include "krado/log.h"
 #include "krado/utils.h"
+#include "krado/timer.h"
 #include "krado/mesh_surface.h"
 #include "krado/scheme/equal.h"
 
@@ -14,7 +15,10 @@ void
 Scheme2D::mesh_surface(Ptr<MeshSurface> surface)
 {
     Log::info("Meshing surface {}: scheme='{}'", surface->id(), name());
-    on_mesh_surface(surface);
+    {
+        LoggingTimer timer;
+        on_mesh_surface(surface);
+    }
 
     if (surface->triangles().size() > 0)
         Log::info("- created {} triangles(s)", utils::human_number(surface->triangles().size()));

--- a/lib/src/scheme3d.cpp
+++ b/lib/src/scheme3d.cpp
@@ -5,6 +5,7 @@
 #include "krado/mesh_surface.h"
 #include "krado/mesh_volume.h"
 #include "krado/log.h"
+#include "krado/timer.h"
 
 namespace krado {
 
@@ -12,7 +13,10 @@ void
 Scheme3D::mesh_volume(Ptr<MeshVolume> volume)
 {
     Log::info("Meshing volume {}: scheme='{}'", volume->id(), name());
-    on_mesh_volume(volume);
+    {
+        LoggingTimer timer;
+        on_mesh_volume(volume);
+    }
 }
 
 void

--- a/lib/src/utils.cpp
+++ b/lib/src/utils.cpp
@@ -139,6 +139,39 @@ set_from_side_set(const Mesh & mesh, const std::vector<SideEntry> & side_set)
     return sset;
 }
 
+std::string
+human_time(double time)
+{
+    using namespace std::chrono;
+    duration<double, std::micro> us(time * 1e6);
+    auto h = duration_cast<hours>(us);
+    us -= h;
+    auto m = duration_cast<minutes>(us);
+    us -= m;
+    auto s = duration_cast<seconds>(us);
+    us -= s;
+    auto ms = duration_cast<milliseconds>(us);
+
+    std::vector<std::string> strs;
+    if (time > 1.) {
+        if (h.count() > 0)
+            strs.push_back(fmt::format("{}h", h.count()));
+        if (m.count() > 0)
+            strs.push_back(fmt::format("{}m", m.count()));
+        // Long running: Show seconds (include ms as decimals, e.g., 5.23s)
+        if ((s.count() > 0) || (h.count() == 0 && m.count() == 0)) {
+            double total_seconds = s.count() + (ms.count() / 1000.0);
+            strs.push_back(fmt::format("{:.2f}s", total_seconds));
+        }
+    }
+    else {
+        // Short running (< 1 second): Show pure milliseconds (e.g., 23.45ms)
+        double total_ms = us.count() / 1000.0;
+        strs.push_back(fmt::format("{:.2f}ms", total_ms));
+    }
+    return join(" ", strs);
+}
+
 } // namespace utils
 
 std::array<Ptr<MeshVertexAbstract>, 3>

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -64,12 +64,29 @@
 #include "krado/vector.h"
 #include "krado/io.h"
 #include "krado/log.h"
+#include "krado/timer.h"
 #include <fmt/core.h>
+#include <thread>
+#include <mutex>
 
 namespace py = pybind11;
 using namespace krado;
 
 PYBIND11_DECLARE_HOLDER_TYPE(T, krado::Ptr<T>);
+
+namespace {
+
+std::once_flag flag;
+std::unique_ptr<LoggingTimer> runtime_timer;
+
+void
+initialize_krado()
+{
+    Log::info("Starting");
+    runtime_timer = std::make_unique<LoggingTimer>("Total time: {}");
+}
+
+} // namespace
 
 class PyMeshVertexAbstract : public MeshVertexAbstract {
 public:
@@ -133,6 +150,8 @@ auto make_span_view = [](auto & self, auto span_getter) {
 
 PYBIND11_MODULE(krado, m)
 {
+    std::call_once(flag, initialize_krado);
+
     m.doc() = "pybind11 plugin for krado";
     m.attr("__version__") = KRADO_VERSION;
 

--- a/test/src/Utils_test.cpp
+++ b/test/src/Utils_test.cpp
@@ -35,3 +35,18 @@ TEST(UtilsTest, join)
     EXPECT_EQ(join(",", std::vector<int> { 1 }), "1");
     EXPECT_EQ(join(",", std::vector<int> { 3, 5 }), "3,5");
 }
+
+TEST(UtilsTest, human_time)
+{
+    EXPECT_EQ(utils::human_time(0), "0.00ms");
+    EXPECT_EQ(utils::human_time(0.0005), "0.50ms");
+    EXPECT_EQ(utils::human_time(0.5), "500.00ms");
+    EXPECT_EQ(utils::human_time(10), "10.00s");
+    EXPECT_EQ(utils::human_time(60), "1m");
+    EXPECT_EQ(utils::human_time(70), "1m 10.00s");
+    EXPECT_EQ(utils::human_time(70.5), "1m 10.50s");
+    EXPECT_EQ(utils::human_time(3600), "1h");
+    EXPECT_EQ(utils::human_time(3720), "1h 2m");
+    EXPECT_EQ(utils::human_time(3725), "1h 2m 5.00s");
+    EXPECT_EQ(utils::human_time(3725.2), "1h 2m 5.20s");
+}


### PR DESCRIPTION
- Adding function for printing time in human-readable form
- Adding `LoggingTimer`
- Report time spent in meshing function in a log
- Adding timing for measuring the run-time of the python scripts
- Adding timing to `ExodusIIFile`
