### PR TITLE
Adding smoothing of surface meshes

### DIFF
--- a/lib/include/krado/log.h
+++ b/lib/include/krado/log.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <string>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
-#include <string>
 
 namespace krado {
 

--- a/lib/include/krado/mesh_curve_vertex.h
+++ b/lib/include/krado/mesh_curve_vertex.h
@@ -33,6 +33,9 @@ public:
     /// @return Physical position in the 3D space
     [[nodiscard]] Point point() const override;
 
+    /// @copydoc MeshVertexAbstract::relocate
+    void relocate(const Point & p) override;
+
 private:
     const GeomCurve & gcurve_;
     /// Parametrical position on the curve

--- a/lib/include/krado/mesh_surface_vertex.h
+++ b/lib/include/krado/mesh_surface_vertex.h
@@ -38,6 +38,9 @@ public:
     /// @return Physical position in the 3D space
     [[nodiscard]] Point point() const override;
 
+    /// @copydoc MeshVertexAbstract::relocate
+    void relocate(const Point & p) override;
+
 private:
     const GeomSurface & gsurface_;
     /// Parametrical position on the curve

--- a/lib/include/krado/mesh_vertex.h
+++ b/lib/include/krado/mesh_vertex.h
@@ -31,6 +31,9 @@ public:
     /// @return Physical position in the 3D space
     [[nodiscard]] Point point() const override;
 
+    /// @copydoc MeshVertexAbstract::relocate
+    void relocate(const Point & p) override;
+
     /// Get the mesh size at the vertex.
     ///
     /// @return The mesh size at the vertex.

--- a/lib/include/krado/mesh_vertex_abstract.h
+++ b/lib/include/krado/mesh_vertex_abstract.h
@@ -18,6 +18,12 @@ public:
     /// @return Physical position in the 3D space
     [[nodiscard]] virtual Point point() const = 0;
 
+    /// Relocate the vertex to a new position. The actual position will be projected
+    /// onto the geometrical shape associated with this vertex.
+    ///
+    /// @param p New physical position
+    virtual void relocate(const Point & p) = 0;
+
     /// Geometrical shape associated with this vertex
     ///
     /// @return Geometrical shape associated with this vertex

--- a/lib/include/krado/ops.h
+++ b/lib/include/krado/ops.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "krado/types.h"
+#include "krado/ptr.h"
 #include "Standard_TypeDef.hxx"
 #include <vector>
 #include <tuple>
@@ -22,6 +23,7 @@ class Vector;
 class Axis1;
 class Wire;
 class Plane;
+class MeshSurface;
 
 /// Translate a shape
 ///
@@ -213,5 +215,11 @@ GeomShape sweep(const GeomShape & profile, const Wire & spine);
 /// @param tol Tolerance
 /// @return Resulting shell
 GeomShape sew(const std::vector<GeomShape> & faces, double tol = 1e-6);
+
+/// Apply Laplace smoothing to a surface mesh
+///
+/// @param surface Surface to smooth
+/// @param iterations Number of iterations
+void smooth(Ptr<MeshSurface> surface, int iterations = 1);
 
 } // namespace krado

--- a/lib/include/krado/types.h
+++ b/lib/include/krado/types.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include "fmt/core.h"
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <span>
+#include "fmt/core.h"
 
 namespace krado {
 

--- a/lib/include/krado/vector.h
+++ b/lib/include/krado/vector.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
+#include <memory>
+#include <ostream>
 #include "fmt/format.h"
 #include "gp_Vec.hxx"
-#include <ostream>
 
 namespace krado {
 

--- a/lib/src/mesh_curve_vertex.cpp
+++ b/lib/src/mesh_curve_vertex.cpp
@@ -32,4 +32,11 @@ MeshCurveVertex::point() const
     return this->phys_pt_;
 }
 
+void
+MeshCurveVertex::relocate(const Point & p)
+{
+    this->u_ = this->gcurve_.parameter_from_point(p);
+    this->phys_pt_ = this->gcurve_.point(this->u_);
+}
+
 } // namespace krado

--- a/lib/src/mesh_surface_vertex.cpp
+++ b/lib/src/mesh_surface_vertex.cpp
@@ -40,4 +40,11 @@ MeshSurfaceVertex::point() const
     return this->phys_pt_;
 }
 
+void
+MeshSurfaceVertex::relocate(const Point & p)
+{
+    this->uv_ = this->gsurface_.parameter_from_point(p);
+    this->phys_pt_ = this->gsurface_.point(this->uv_);
+}
+
 } // namespace krado

--- a/lib/src/mesh_vertex.cpp
+++ b/lib/src/mesh_vertex.cpp
@@ -34,6 +34,12 @@ MeshVertex::point() const
     return this->gvtx_.point();
 }
 
+void
+MeshVertex::relocate(const Point & /*p*/)
+{
+    // A corner vertex cannot be relocated
+}
+
 double
 MeshVertex::mesh_size() const
 {

--- a/lib/src/ops.cpp
+++ b/lib/src/ops.cpp
@@ -10,11 +10,17 @@
 #include "krado/exception.h"
 #include "krado/log.h"
 #include "krado/mesh.h"
+#include "krado/mesh_surface.h"
+#include "krado/mesh_surface_vertex.h"
+#include "krado/mesh_vertex_abstract.h"
+#include "krado/mesh_element.h"
 #include "krado/types.h"
 #include "krado/vector.h"
 #include "krado/wire.h"
 #include "krado/plane.h"
 #include "krado/axis1.h"
+#include "krado/range.h"
+#include "krado/timer.h"
 #include "Geom_TrimmedCurve.hxx"
 #include "BRepBuilderAPI_MakeEdge.hxx"
 #include "BRepBuilderAPI_MakeWire.hxx"
@@ -41,6 +47,7 @@
 #include "BRepAlgoAPI_Splitter.hxx"
 #include "TopoDS_Edge.hxx"
 #include "TopTools_DataMapOfShapeInteger.hxx"
+#include <set>
 
 namespace krado {
 
@@ -505,6 +512,61 @@ sew(const std::vector<GeomShape> & faces, double tol)
         sewing_tool.Add(face);
     sewing_tool.Perform();
     return GeomShape(sewing_tool.SewedShape());
+}
+
+void
+smooth(Ptr<MeshSurface> surface, int iterations)
+{
+    LoggingTimer timer;
+    Log::info("Applying Laplace smoothing on surface {} ({} iterations)",
+              surface->id(),
+              iterations);
+
+    // 1. Build adjacency map for internal vertices
+    std::map<Ptr<MeshVertexAbstract>, std::set<Ptr<MeshVertexAbstract>>> neighbors;
+
+    for (auto vtx : surface->surface_vertices())
+        neighbors[vtx] = {};
+
+    auto add_neighbors = [&](const MeshElement & elem) {
+        auto vtxs = elem.vertices();
+        for (auto i : make_range(vtxs.size())) {
+            auto vtx = vtxs[i];
+            auto it = neighbors.find(vtx);
+            if (it != neighbors.end()) {
+                for (auto j : make_range(vtxs.size())) {
+                    if (i != j) {
+                        it->second.insert(vtxs[j]);
+                    }
+                }
+            }
+        }
+    };
+
+    for (auto tri : surface->triangles())
+        add_neighbors(tri);
+    for (auto quad : surface->quadrangles())
+        add_neighbors(quad);
+
+    // 2. Perform Laplace iterations
+    for (auto iter : make_range(iterations)) {
+        (void) iter;
+        std::map<Ptr<MeshVertexAbstract>, Point> new_positions;
+        for (const auto & [vtx, adj] : neighbors) {
+            Point avg(0, 0, 0);
+            for (const auto & neighbor : adj)
+                avg += neighbor->point();
+
+            if (adj.size() > 0) {
+                avg *= 1.0 / adj.size();
+                new_positions[vtx] = avg;
+            }
+        }
+
+        // Relocate vertices
+        for (const auto & [vtx, pos] : new_positions)
+            vtx->relocate(pos);
+    }
 }
 
 } // namespace krado

--- a/python/src/krado.cpp
+++ b/python/src/krado.cpp
@@ -786,6 +786,8 @@ PYBIND11_MODULE(krado, m)
 
     m.def("tetrahedralize", &tetrahedralize);
 
+    m.def("smooth", &smooth, py::arg("surface"), py::arg("iterations") = 1);
+
     m.def("export_mesh", &IO::export_mesh, py::arg("file_name"), py::arg("mesh"));
     m.def("import_mesh", &IO::import_mesh, py::arg("file_name"));
 

--- a/test/src/Smoothing_test.cpp
+++ b/test/src/Smoothing_test.cpp
@@ -1,0 +1,124 @@
+#include "gmock/gmock.h"
+#include "builder.h"
+#include "krado/mesh_vertex.h"
+#include "krado/mesh_curve.h"
+#include "krado/mesh_curve_vertex.h"
+#include "krado/mesh_surface_vertex.h"
+#include "krado/mesh_surface.h"
+#include "krado/geom_vertex.h"
+#include "krado/geom_curve.h"
+#include "krado/geom_surface.h"
+#include "krado/line.h"
+#include "krado/ops.h"
+#include "krado/ptr.h"
+
+using namespace krado;
+using namespace testing;
+
+TEST(SmoothingTest, relocate_corner)
+{
+    auto gv = build_vertex(Point(1, 2, 3));
+    MeshVertex mv(1, gv);
+
+    EXPECT_THAT(mv.point().x, DoubleEq(1.0));
+
+    mv.relocate(Point(10, 10, 10));
+    // Corner should not move
+    EXPECT_THAT(mv.point().x, DoubleEq(1.0));
+    EXPECT_THAT(mv.point().y, DoubleEq(2.0));
+    EXPECT_THAT(mv.point().z, DoubleEq(3.0));
+}
+
+TEST(SmoothingTest, relocate_curve)
+{
+    auto line = build_line(Point(0, 0, 0), Point(10, 0, 0));
+    MeshCurveVertex mcv(line, 5.0); // Midpoint
+
+    EXPECT_THAT(mcv.point().x, DoubleEq(5.0));
+
+    // Relocate to a point slightly off the line
+    mcv.relocate(Point(6.0, 1.0, 1.0));
+
+    // Should snap back to the line (x=6, y=0, z=0)
+    EXPECT_THAT(mcv.point().x, DoubleEq(6.0));
+    EXPECT_THAT(mcv.point().y, DoubleEq(0.0));
+    EXPECT_THAT(mcv.point().z, DoubleEq(0.0));
+    EXPECT_THAT(mcv.parameter(), DoubleEq(6.0));
+}
+
+TEST(SmoothingTest, relocate_surface)
+{
+    auto rect = build_rect(Point(0, 0, 0), Point(10, 10, 0));
+    MeshSurfaceVertex msv(rect, 0.0, 0.0);
+
+    EXPECT_THAT(msv.point().x, DoubleEq(5.0));
+    EXPECT_THAT(msv.point().y, DoubleEq(5.0));
+    EXPECT_THAT(msv.point().z, DoubleEq(0.0));
+
+    // Relocate off the surface
+    msv.relocate(Point(6.0, 7.0, 1.0));
+
+    // Should snap back to z=0
+    EXPECT_THAT(msv.point().x, DoubleEq(6.0));
+    EXPECT_THAT(msv.point().y, DoubleEq(7.0));
+    EXPECT_THAT(msv.point().z, DoubleEq(0.0));
+    EXPECT_THAT(msv.parameter().u, DoubleEq(1.));
+    EXPECT_THAT(msv.parameter().v, DoubleEq(2.));
+}
+
+TEST(SmoothingTest, smooth_surface)
+{
+    auto rect = build_rect(Point(0., 0., 0.), Point(3., 2., 0.));
+
+    auto curves = rect.curves();
+    GeomVertex gv1(curves[3].last_vertex());
+    GeomVertex gv2(curves[0].last_vertex());
+    GeomVertex gv3(curves[2].last_vertex());
+    GeomVertex gv4(curves[1].last_vertex());
+
+    // Create a 2x2 grid of vertices
+    // V6 V7 V8
+    // V3 V4 V5
+    // V0 V1 V2
+
+    auto v0 = Ptr<MeshVertex>::alloc(1, gv1); // (0,0,0)
+    auto v1 = Ptr<MeshCurveVertex>::alloc(curves[0], 1.0); // (1,0,0)
+    auto v2 = Ptr<MeshVertex>::alloc(2, gv2); // (3,0,0)
+
+    auto v3 = Ptr<MeshCurveVertex>::alloc(curves[3], 1.0); // (0,1,0)
+    auto v4 = Ptr<MeshSurfaceVertex>::alloc(rect, 0.2, 0.2); // Distorted from (1.5,1)
+    auto v5 = Ptr<MeshCurveVertex>::alloc(curves[1], 1.0); // (3,1,0)
+
+    auto v6 = Ptr<MeshVertex>::alloc(3, gv3); // (0,2,0)
+    auto v7 = Ptr<MeshCurveVertex>::alloc(curves[2], 1.0); // (2,2,0)
+    auto v8 = Ptr<MeshVertex>::alloc(4, gv4); // (3,2,0)
+
+    std::vector<Ptr<MeshCurve>> mcrvs;
+    auto surface = Ptr<MeshSurface>::alloc(1, rect, mcrvs);
+    surface->add_vertex(v4);
+
+    // Triangles for the 4 quads
+    surface->add_triangle({ v0, v1, v4 });
+    surface->add_triangle({ v0, v4, v3 });
+
+    surface->add_triangle({ v1, v2, v4 });
+    surface->add_triangle({ v2, v5, v4 });
+
+    surface->add_triangle({ v3, v4, v6 });
+    surface->add_triangle({ v4, v7, v6 });
+
+    surface->add_triangle({ v4, v5, v8 });
+    surface->add_triangle({ v4, v8, v7 });
+
+    // Initial position of internal vertex is (1.7, 1.2, 0)
+    EXPECT_THAT(v4->point().x, DoubleEq(1.7));
+    EXPECT_THAT(v4->point().y, DoubleEq(1.2));
+
+    // Smooth
+    krado::smooth(surface, 2);
+
+    // New position should be average of neighbors (1,1,0)
+    EXPECT_NEAR(v4->point().x, 1.5, 1e-7);
+    EXPECT_NEAR(v4->point().y, 1.0, 1e-7);
+    EXPECT_THAT(v4->point().z, DoubleEq(0.0));
+}


### PR DESCRIPTION
- Adding `MeshVertexAbstract::relocate`
- Adding `smooth` for `MeshSurface`s
- Adding tests
- Adding python wrapper

Refs #14 