### PR TITLE
Improving element type support in `compute_volume`

### DIFF
--- a/lib/include/krado/fe_values.h
+++ b/lib/include/krado/fe_values.h
@@ -1,0 +1,506 @@
+// SPDX-FileCopyrightText: 2026 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "krado/element.h"
+#include "krado/mesh.h"
+#include "krado/point.h"
+#include "krado/vector.h"
+#include "krado/quadrature.h"
+
+namespace krado {
+
+/// Finite element values
+template <ElementType ET>
+struct FEValues {
+    /// Compute shape function value
+    ///
+    /// @param i Node index
+    /// @param p Point in reference space
+    /// @return Shape function value
+    static double shape_val(u8 i, const Point & p);
+
+    /// Compute shape function derivative
+    ///
+    /// @param i Node index
+    /// @param p Point in reference space
+    /// @return Shape function derivative
+    static Vector shape_der(u8 i, const Point & p);
+
+    /// Compute Jacobian determinant
+    ///
+    /// @param elem Element
+    /// @param mesh Mesh
+    /// @param p Point in reference space
+    /// @return Jacobian determinant
+    static double compute_det_J(const Element & elem, const Mesh & mesh, const Point & p);
+};
+
+// LINE2
+template <>
+struct FEValues<ElementType::LINE2> {
+    static double
+    shape_val(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        switch (i) {
+        case 0:
+            return 0.5 * (1. - xi);
+        case 1:
+            return 0.5 * (1. + xi);
+        default:
+            return 0.;
+        }
+    }
+
+    static Vector
+    shape_der(u8 i, const Point & p)
+    {
+        (void) p;
+        switch (i) {
+        case 0:
+            return Vector(-0.5, 0., 0.);
+        case 1:
+            return Vector(0.5, 0., 0.);
+        default:
+            return Vector(0., 0., 0.);
+        }
+    }
+
+    static double
+    compute_det_J(const Element & elem, const Mesh & mesh, const Point & p)
+    {
+        Vector dxdxi(0, 0, 0);
+        auto idxs = elem.indices();
+        for (u8 i = 0; i < Line2::N_VERTICES; ++i) {
+            const auto deriv = shape_der(i, p);
+            const Vector pt(mesh.point(idxs[i]));
+            dxdxi += deriv.x * pt;
+        }
+        return dxdxi.magnitude();
+    }
+};
+
+// TRI3
+template <>
+struct FEValues<ElementType::TRI3> {
+    static double
+    shape_val(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        switch (i) {
+        case 0:
+            return 1. - xi - eta;
+        case 1:
+            return xi;
+        case 2:
+            return eta;
+        default:
+            return 0.;
+        }
+    }
+
+    static Vector
+    shape_der(u8 i, const Point & p)
+    {
+        (void) p;
+        switch (i) {
+        case 0:
+            return Vector(-1., -1., 0.);
+        case 1:
+            return Vector(1., 0., 0.);
+        case 2:
+            return Vector(0., 1., 0.);
+        default:
+            return Vector(0., 0., 0.);
+        }
+    }
+
+    static double
+    compute_det_J(const Element & elem, const Mesh & mesh, const Point & p)
+    {
+        Vector dxdxi(0, 0, 0);
+        Vector dxdeta(0, 0, 0);
+        auto idxs = elem.indices();
+        for (u8 i = 0; i < Tri3::N_VERTICES; ++i) {
+            const auto der = shape_der(i, p);
+            const Vector pt(mesh.point(idxs[i]));
+            dxdxi += der.x * pt;
+            dxdeta += der.y * pt;
+        }
+        return cross_product(dxdxi, dxdeta).magnitude();
+    }
+};
+
+// QUAD4
+template <>
+struct FEValues<ElementType::QUAD4> {
+    static double
+    shape_val(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        switch (i) {
+        case 0:
+            return 0.25 * (1. - xi) * (1. - eta);
+        case 1:
+            return 0.25 * (1. + xi) * (1. - eta);
+        case 2:
+            return 0.25 * (1. + xi) * (1. + eta);
+        case 3:
+            return 0.25 * (1. - xi) * (1. + eta);
+        default:
+            return 0.;
+        }
+    }
+
+    static Vector
+    shape_der(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        switch (i) {
+        case 0:
+            return Vector(-0.25 * (1. - eta), -0.25 * (1. - xi), 0.);
+        case 1:
+            return Vector(0.25 * (1. - eta), -0.25 * (1. + xi), 0.);
+        case 2:
+            return Vector(0.25 * (1. + eta), 0.25 * (1. + xi), 0.);
+        case 3:
+            return Vector(-0.25 * (1. + eta), 0.25 * (1. - xi), 0.);
+        default:
+            return Vector(0., 0., 0.);
+        }
+    }
+
+    static double
+    compute_det_J(const Element & elem, const Mesh & mesh, const Point & p)
+    {
+        Vector dxdxi(0, 0, 0);
+        Vector dxdeta(0, 0, 0);
+        auto idxs = elem.indices();
+        for (u8 i = 0; i < Quad4::N_VERTICES; ++i) {
+            const auto der = shape_der(i, p);
+            const Vector pt(mesh.point(idxs[i]));
+            dxdxi += der.x * pt;
+            dxdeta += der.y * pt;
+        }
+        return cross_product(dxdxi, dxdeta).magnitude();
+    }
+};
+
+// TETRA4
+template <>
+struct FEValues<ElementType::TETRA4> {
+    static double
+    shape_val(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        const double zeta = p.z;
+        switch (i) {
+        case 0:
+            return 1. - xi - eta - zeta;
+        case 1:
+            return xi;
+        case 2:
+            return eta;
+        case 3:
+            return zeta;
+        default:
+            return 0.;
+        }
+    }
+
+    static Vector
+    shape_der(u8 i, const Point & p)
+    {
+        (void) p;
+        switch (i) {
+        case 0:
+            return Vector(-1., -1., -1.);
+        case 1:
+            return Vector(1., 0., 0.);
+        case 2:
+            return Vector(0., 1., 0.);
+        case 3:
+            return Vector(0., 0., 1.);
+        default:
+            return Vector(0., 0., 0.);
+        }
+    }
+
+    static double
+    compute_det_J(const Element & elem, const Mesh & mesh, const Point & p)
+    {
+        Vector dxdxi(0, 0, 0);
+        Vector dxdeta(0, 0, 0);
+        Vector dxdzeta(0, 0, 0);
+        auto idxs = elem.indices();
+        for (u8 i = 0; i < Tetra4::N_VERTICES; ++i) {
+            const auto der = shape_der(i, p);
+            const Vector pt(mesh.point(idxs[i]));
+            dxdxi += der.x * pt;
+            dxdeta += der.y * pt;
+            dxdzeta += der.z * pt;
+        }
+        return std::abs(dot_product(dxdxi, cross_product(dxdeta, dxdzeta)));
+    }
+};
+
+// HEX8
+template <>
+struct FEValues<ElementType::HEX8> {
+    static double
+    shape_val(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        const double zeta = p.z;
+        switch (i) {
+        case 0:
+            return 0.125 * (1. - xi) * (1. - eta) * (1. - zeta);
+        case 1:
+            return 0.125 * (1. + xi) * (1. - eta) * (1. - zeta);
+        case 2:
+            return 0.125 * (1. + xi) * (1. + eta) * (1. - zeta);
+        case 3:
+            return 0.125 * (1. - xi) * (1. + eta) * (1. - zeta);
+        case 4:
+            return 0.125 * (1. - xi) * (1. - eta) * (1. + zeta);
+        case 5:
+            return 0.125 * (1. + xi) * (1. - eta) * (1. + zeta);
+        case 6:
+            return 0.125 * (1. + xi) * (1. + eta) * (1. + zeta);
+        case 7:
+            return 0.125 * (1. - xi) * (1. + eta) * (1. + zeta);
+        default:
+            return 0.;
+        }
+    }
+
+    static Vector
+    shape_der(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        const double zeta = p.z;
+        switch (i) {
+        case 0:
+            return Vector(-0.125 * (1. - eta) * (1. - zeta),
+                          -0.125 * (1. - xi) * (1. - zeta),
+                          -0.125 * (1. - xi) * (1. - eta));
+        case 1:
+            return Vector(0.125 * (1. - eta) * (1. - zeta),
+                          -0.125 * (1. + xi) * (1. - zeta),
+                          -0.125 * (1. + xi) * (1. - eta));
+        case 2:
+            return Vector(0.125 * (1. + eta) * (1. - zeta),
+                          0.125 * (1. + xi) * (1. - zeta),
+                          -0.125 * (1. + xi) * (1. + eta));
+        case 3:
+            return Vector(-0.125 * (1. + eta) * (1. - zeta),
+                          0.125 * (1. - xi) * (1. - zeta),
+                          -0.125 * (1. - xi) * (1. + eta));
+        case 4:
+            return Vector(-0.125 * (1. - eta) * (1. + zeta),
+                          -0.125 * (1. - xi) * (1. + zeta),
+                          0.125 * (1. - xi) * (1. - eta));
+        case 5:
+            return Vector(0.125 * (1. - eta) * (1. + zeta),
+                          -0.125 * (1. + xi) * (1. + zeta),
+                          0.125 * (1. + xi) * (1. - eta));
+        case 6:
+            return Vector(0.125 * (1. + eta) * (1. + zeta),
+                          0.125 * (1. + xi) * (1. + zeta),
+                          0.125 * (1. + xi) * (1. + eta));
+        case 7:
+            return Vector(-0.125 * (1. + eta) * (1. + zeta),
+                          0.125 * (1. - xi) * (1. + zeta),
+                          0.125 * (1. - xi) * (1. + eta));
+        default:
+            return Vector(0., 0., 0.);
+        }
+    }
+
+    static double
+    compute_det_J(const Element & elem, const Mesh & mesh, const Point & p)
+    {
+        Vector dxdxi(0, 0, 0);
+        Vector dxdeta(0, 0, 0);
+        Vector dxdzeta(0, 0, 0);
+        auto idxs = elem.indices();
+        for (u8 i = 0; i < Hex8::N_VERTICES; ++i) {
+            const auto der = shape_der(i, p);
+            const Vector pt(mesh.point(idxs[i]));
+            dxdxi += der.x * pt;
+            dxdeta += der.y * pt;
+            dxdzeta += der.z * pt;
+        }
+        return std::abs(dot_product(dxdxi, cross_product(dxdeta, dxdzeta)));
+    }
+};
+
+// PRISM6
+template <>
+struct FEValues<ElementType::PRISM6> {
+    static double
+    shape_val(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        const double zeta = p.z;
+        switch (i) {
+        case 0:
+            return (1. - xi - eta) * 0.5 * (1. - zeta);
+        case 1:
+            return xi * 0.5 * (1. - zeta);
+        case 2:
+            return eta * 0.5 * (1. - zeta);
+        case 3:
+            return (1. - xi - eta) * 0.5 * (1. + zeta);
+        case 4:
+            return xi * 0.5 * (1. + zeta);
+        case 5:
+            return eta * 0.5 * (1. + zeta);
+        default:
+            return 0.;
+        }
+    }
+
+    static Vector
+    shape_der(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        const double zeta = p.z;
+        switch (i) {
+        case 0:
+            return Vector(-0.5 * (1. - zeta), -0.5 * (1. - zeta), -0.5 * (1. - xi - eta));
+        case 1:
+            return Vector(0.5 * (1. - zeta), 0.0, -0.5 * xi);
+        case 2:
+            return Vector(0.0, 0.5 * (1. - zeta), -0.5 * eta);
+        case 3:
+            return Vector(-0.5 * (1. + zeta), -0.5 * (1. + zeta), 0.5 * (1. - xi - eta));
+        case 4:
+            return Vector(0.5 * (1. + zeta), 0.0, 0.5 * xi);
+        case 5:
+            return Vector(0.0, 0.5 * (1. + zeta), 0.5 * eta);
+        default:
+            return Vector(0., 0., 0.);
+        }
+    }
+
+    static double
+    compute_det_J(const Element & elem, const Mesh & mesh, const Point & p)
+    {
+        Vector dxdxi(0, 0, 0);
+        Vector dxdeta(0, 0, 0);
+        Vector dxdzeta(0, 0, 0);
+        auto idxs = elem.indices();
+        for (u8 i = 0; i < Prism6::N_VERTICES; ++i) {
+            const auto der = shape_der(i, p);
+            const Vector pt(mesh.point(idxs[i]));
+            dxdxi += der.x * pt;
+            dxdeta += der.y * pt;
+            dxdzeta += der.z * pt;
+        }
+        return std::abs(dot_product(dxdxi, cross_product(dxdeta, dxdzeta)));
+    }
+};
+
+// PYRAMID5
+template <>
+struct FEValues<ElementType::PYRAMID5> {
+    static double
+    shape_val(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        const double zeta = p.z;
+        switch (i) {
+        case 0:
+            return 0.25 * (1. - xi) * (1. - eta) * (1. - zeta);
+        case 1:
+            return 0.25 * (1. + xi) * (1. - eta) * (1. - zeta);
+        case 2:
+            return 0.25 * (1. + xi) * (1. + eta) * (1. - zeta);
+        case 3:
+            return 0.25 * (1. - xi) * (1. + eta) * (1. - zeta);
+        case 4:
+            return zeta;
+        default:
+            return 0.;
+        }
+    }
+
+    static Vector
+    shape_der(u8 i, const Point & p)
+    {
+        const double xi = p.x;
+        const double eta = p.y;
+        const double zeta = p.z;
+        switch (i) {
+        case 0:
+            return Vector(-0.25 * (1. - eta) * (1. - zeta),
+                          -0.25 * (1. - xi) * (1. - zeta),
+                          -0.25 * (1. - xi) * (1. - eta));
+        case 1:
+            return Vector(0.25 * (1. - eta) * (1. - zeta),
+                          -0.25 * (1. + xi) * (1. - zeta),
+                          -0.25 * (1. + xi) * (1. - eta));
+        case 2:
+            return Vector(0.25 * (1. + eta) * (1. - zeta),
+                          0.25 * (1. + xi) * (1. - zeta),
+                          -0.25 * (1. + xi) * (1. + eta));
+        case 3:
+            return Vector(-0.25 * (1. + eta) * (1. - zeta),
+                          0.25 * (1. - xi) * (1. - zeta),
+                          -0.25 * (1. - xi) * (1. + eta));
+        case 4:
+            return Vector(0, 0, 1);
+        default:
+            return Vector(0, 0, 0);
+        }
+    }
+
+    static double
+    compute_det_J(const Element & elem, const Mesh & mesh, const Point & p)
+    {
+        Vector dxdxi(0, 0, 0);
+        Vector dxdeta(0, 0, 0);
+        Vector dxdzeta(0, 0, 0);
+        auto idxs = elem.indices();
+        for (u8 i = 0; i < Pyramid5::N_VERTICES; ++i) {
+            const auto der = shape_der(i, p);
+            const Vector pt(mesh.point(idxs[i]));
+            dxdxi += der.x * pt;
+            dxdeta += der.y * pt;
+            dxdzeta += der.z * pt;
+        }
+        return std::abs(dot_product(dxdxi, cross_product(dxdeta, dxdzeta)));
+    }
+};
+
+/// Integrate volume of an element
+///
+/// @tparam ET Element type
+/// @param elem Element
+/// @param mesh Mesh
+/// @return Volume
+template <ElementType ET>
+double
+integrate_volume(const Element & elem, const Mesh & mesh)
+{
+    auto qpts = Quadrature::get(ET);
+    double volume = 0;
+    for (auto & qp : qpts) {
+        volume += qp.weight * FEValues<ET>::compute_det_J(elem, mesh, qp.point);
+    }
+    return volume;
+}
+
+} // namespace krado

--- a/lib/include/krado/quadrature.h
+++ b/lib/include/krado/quadrature.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "krado/types.h"
+#include "krado/point.h"
+#include <vector>
+
+namespace krado {
+
+/// Quadrature point
+struct QuadraturePoint {
+    /// Coordinate in reference space
+    Point point;
+    /// Weight
+    double weight;
+};
+
+/// Quadrature rules
+class Quadrature {
+public:
+    /// Get quadrature rule for an element type
+    ///
+    /// @param type Element type
+    /// @return Quadrature points and weights
+    static std::vector<QuadraturePoint> get(ElementType type);
+};
+
+} // namespace krado

--- a/lib/src/ops.cpp
+++ b/lib/src/ops.cpp
@@ -21,6 +21,7 @@
 #include "krado/axis1.h"
 #include "krado/range.h"
 #include "krado/timer.h"
+#include "krado/fe_values.h"
 #include "Geom_TrimmedCurve.hxx"
 #include "BRepBuilderAPI_MakeEdge.hxx"
 #include "BRepBuilderAPI_MakeWire.hxx"
@@ -209,26 +210,26 @@ compute_volume(const Mesh & mesh)
 {
     auto element_volume = [&](const Element & elem) {
         switch (elem.type()) {
-        case ElementType::LINE2: {
-            auto idxs = elem.indices();
-            auto vec = mesh.point(idxs[1]) - mesh.point(idxs[0]);
-            return vec.magnitude();
-        }
+        case ElementType::LINE2:
+            return integrate_volume<ElementType::LINE2>(elem, mesh);
 
-        case ElementType::TRI3: {
-            auto idxs = elem.indices();
-            auto va = mesh.point(idxs[1]) - mesh.point(idxs[0]);
-            auto vb = mesh.point(idxs[2]) - mesh.point(idxs[0]);
-            return 0.5 * cross_product(va, vb).magnitude();
-        }
+        case ElementType::TRI3:
+            return integrate_volume<ElementType::TRI3>(elem, mesh);
 
-        case ElementType::TETRA4: {
-            auto idxs = elem.indices();
-            auto va = mesh.point(idxs[1]) - mesh.point(idxs[0]);
-            auto vb = mesh.point(idxs[2]) - mesh.point(idxs[0]);
-            auto vc = mesh.point(idxs[3]) - mesh.point(idxs[0]);
-            return std::abs(dot_product(va, cross_product(vb, vc))) / 6.;
-        }
+        case ElementType::QUAD4:
+            return integrate_volume<ElementType::QUAD4>(elem, mesh);
+
+        case ElementType::TETRA4:
+            return integrate_volume<ElementType::TETRA4>(elem, mesh);
+
+        case ElementType::PYRAMID5:
+            return integrate_volume<ElementType::PYRAMID5>(elem, mesh);
+
+        case ElementType::PRISM6:
+            return integrate_volume<ElementType::PRISM6>(elem, mesh);
+
+        case ElementType::HEX8:
+            return integrate_volume<ElementType::HEX8>(elem, mesh);
 
         default:
             throw Exception("compute_volume: Unsupported element type {}", elem.type());

--- a/lib/src/quadrature.cpp
+++ b/lib/src/quadrature.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "krado/quadrature.h"
+#include "krado/element.h"
+#include "krado/exception.h"
+#include <cmath>
+
+namespace krado {
+
+std::vector<QuadraturePoint>
+Quadrature::get(ElementType type)
+{
+    switch (type) {
+    case ElementType::LINE2:
+        return { { Point(0, 0, 0), 2.0 } };
+
+    case ElementType::TRI3:
+        return { { Point(1. / 3., 1. / 3., 0.), 0.5 } };
+
+    case ElementType::QUAD4:
+        return { { Point(0, 0, 0), 4.0 } };
+
+    case ElementType::TETRA4:
+        return { { Point(0.25, 0.25, 0.25), 1. / 6. } };
+
+    case ElementType::HEX8:
+        return { { Point(0, 0, 0), 8.0 } };
+
+    case ElementType::PRISM6:
+        return { { Point(1. / 3., 1. / 3., 0.), 1.0 } };
+
+    case ElementType::PYRAMID5:
+        return { { Point(0, 0, 1.0 - 1.0 / std::sqrt(3.0)), 4.0 } };
+
+    default:
+        throw Exception("Quadrature not implemented for element type {}", type);
+    }
+}
+
+} // namespace krado

--- a/test/src/ComputeVolume_test.cpp
+++ b/test/src/ComputeVolume_test.cpp
@@ -122,6 +122,39 @@ TEST(ComputeVolumeTest, volume_of_a_prism6)
     EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(0.5, 1e-10))));
 }
 
+TEST(ComputeVolumeTest, volume_of_a_prism6_blocks)
+{
+    // 2x1x3 domain, 2 layers of PRISM6 on a 2-triangle base
+    // Points: 3 layers of 4 points = 12 points
+    std::vector<Point> pts;
+    for (double z : { 0.0, 1.5, 3.0 }) {
+        pts.push_back(Point(0, 0, z)); // 0, 4, 8
+        pts.push_back(Point(2, 0, z)); // 1, 5, 9
+        pts.push_back(Point(2, 1, z)); // 2, 6, 10
+        pts.push_back(Point(0, 1, z)); // 3, 7, 11
+    }
+
+    std::vector<Element> elements = {
+        // Layer 1
+        Element::Prism6({ 0, 1, 2, 4, 5, 6 }), // P0
+        Element::Prism6({ 0, 2, 3, 4, 6, 7 }), // P1
+        // Layer 2
+        Element::Prism6({ 4, 5, 6, 8, 9, 10 }), // P2
+        Element::Prism6({ 4, 6, 7, 8, 10, 11 }), // P3
+    };
+
+    Mesh mesh(pts, elements);
+    // Block 1: 1 element (expected volume 1 * 1.5 = 1.5)
+    mesh.set_cell_set(10, { 0 });
+    // Block 2: 3 elements (expected volume 3 * 1.5 = 4.5)
+    mesh.set_cell_set(20, { 1, 2, 3 });
+
+    auto vols = compute_volume(mesh);
+    EXPECT_THAT(
+        vols,
+        UnorderedElementsAre(Pair(10, DoubleNear(1.5, 1e-10)), Pair(20, DoubleNear(4.5, 1e-10))));
+}
+
 TEST(ComputeVolumeTest, volume_of_a_pyramid5)
 {
     std::vector<Point> points = {

--- a/test/src/ComputeVolume_test.cpp
+++ b/test/src/ComputeVolume_test.cpp
@@ -92,6 +92,31 @@ TEST(ComputeVolumeTest, volume_of_a_pyramid5)
     EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(4. / 3., 1e-10))));
 }
 
+TEST(ComputeVolumeTest, area_of_a_quad4_blocks)
+{
+    // Domain: 4x2
+    std::vector<Point> pts = {
+        Point(0, 0, 0), Point(2, 0, 0), Point(4, 0, 0), Point(0, 1, 0), Point(2, 1, 0),
+        Point(4, 1, 0), Point(0, 2, 0), Point(2, 2, 0), Point(4, 2, 0),
+    };
+    std::vector<Element> elements = {
+        Element::Quad4({ 0, 1, 4, 3 }), // Quad 0
+        Element::Quad4({ 1, 2, 5, 4 }), // Quad 1
+        Element::Quad4({ 3, 4, 7, 6 }), // Quad 2
+        Element::Quad4({ 4, 5, 8, 7 }), // Quad 3
+    };
+    Mesh mesh(pts, elements);
+    // Block 1: Quad 0 (area 2)
+    mesh.set_cell_set(10, { 0 });
+    // Block 2: Quads 1, 2, 3 (area 2+2+2 = 6)
+    mesh.set_cell_set(20, { 1, 2, 3 });
+
+    auto vols = compute_volume(mesh);
+    EXPECT_THAT(
+        vols,
+        UnorderedElementsAre(Pair(10, DoubleNear(2., 1e-10)), Pair(20, DoubleNear(6., 1e-10))));
+}
+
 TEST(ComputeVolumeTest, area_of_a_quad4_skewed)
 {
     std::vector<Point> points = {

--- a/test/src/ComputeVolume_test.cpp
+++ b/test/src/ComputeVolume_test.cpp
@@ -45,3 +45,68 @@ TEST(ComputeVolumeTest, volume_of_a_cube_tet4)
     auto vols = compute_volume(mesh);
     EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(1., 1e-10))));
 }
+
+TEST(ComputeVolumeTest, area_of_a_quad4)
+{
+    std::vector<Point> points = {
+        Point(0, 0, 0),
+        Point(1, 0, 0),
+        Point(1, 1, 0),
+        Point(0, 1, 0),
+    };
+    std::vector<Element> elements = { Element::Quad4({ 0, 1, 2, 3 }) };
+    Mesh mesh(points, elements);
+    auto vols = compute_volume(mesh);
+    EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(1., 1e-10))));
+}
+
+TEST(ComputeVolumeTest, volume_of_a_hex8)
+{
+    std::vector<Point> points = {
+        Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0), Point(0, 1, 0),
+        Point(0, 0, 1), Point(1, 0, 1), Point(1, 1, 1), Point(0, 1, 1),
+    };
+    std::vector<Element> elements = { Element::Hex8({ 0, 1, 2, 3, 4, 5, 6, 7 }) };
+    Mesh mesh(points, elements);
+    auto vols = compute_volume(mesh);
+    EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(1., 1e-10))));
+}
+
+TEST(ComputeVolumeTest, volume_of_a_prism6)
+{
+    std::vector<Point> points = {
+        Point(0, 0, 0), Point(1, 0, 0), Point(0, 1, 0),
+        Point(0, 0, 1), Point(1, 0, 1), Point(0, 1, 1),
+    };
+    std::vector<Element> elements = { Element::Prism6({ 0, 1, 2, 3, 4, 5 }) };
+    Mesh mesh(points, elements);
+    auto vols = compute_volume(mesh);
+    EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(0.5, 1e-10))));
+}
+
+TEST(ComputeVolumeTest, volume_of_a_pyramid5)
+{
+    std::vector<Point> points = {
+        Point(-1, -1, 0), Point(1, -1, 0), Point(1, 1, 0), Point(-1, 1, 0), Point(0, 0, 1),
+    };
+    std::vector<Element> elements = { Element::Pyramid5({ 0, 1, 2, 3, 4 }) };
+    Mesh mesh(points, elements);
+    auto vols = compute_volume(mesh);
+    // Base area = 4, height = 1, Volume = 4/3
+    EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(4. / 3., 1e-10))));
+}
+
+TEST(ComputeVolumeTest, area_of_a_quad4_skewed)
+{
+    std::vector<Point> points = {
+        Point(0, 0, 0),
+        Point(2, 0, 0),
+        Point(3, 2, 0),
+        Point(1, 2, 0),
+    };
+    std::vector<Element> elements = { Element::Quad4({ 0, 1, 2, 3 }) };
+    Mesh mesh(points, elements);
+    auto vols = compute_volume(mesh);
+    // Parallelogram with base 2 and height 2. Area = 4.
+    EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(4., 1e-10))));
+}

--- a/test/src/ComputeVolume_test.cpp
+++ b/test/src/ComputeVolume_test.cpp
@@ -1,33 +1,29 @@
 #include "gmock/gmock.h"
-#include "builder.h"
 #include "krado/geom_model.h"
 #include "krado/mesh_vertex.h"
-#include "krado/mesh_curve.h"
-#include "krado/mesh_surface.h"
 #include "krado/ops.h"
 #include "krado/exodusii_file.h"
-#include "krado/scheme/equal.h"
 #include <filesystem>
 
 using namespace krado;
 using namespace testing;
 namespace fs = std::filesystem;
 
-TEST(ComputeVolumeTest, DISABLED_length_of_a_line)
+TEST(ComputeVolumeTest, length_of_a_line)
 {
-    auto ln = build_line(Point(0, 0, 0), Point(3, 4, 0));
-    GeomModel model(ln);
-
-    SchemeEqual::Options opts;
-    opts.intervals = 5;
-    model.curve(1)->set_scheme<SchemeEqual>(opts);
-
-    model.mesh_curve(1);
-    // FIXME
-    // auto mesh = build_mesh(model);
-    //
-    // auto vols = compute_volume(mesh);
-    // EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(5., 1e-10))));
+    std::vector<Point> points = {
+        Point(0, 0, 0),      Point(0.75, 1.0, 0), Point(1.5, 2.0, 0),
+        Point(2.25, 3.0, 0), Point(3.0, 4.0, 0),
+    };
+    std::vector<Element> elements = {
+        Element::Line2({ 0, 1 }),
+        Element::Line2({ 1, 2 }),
+        Element::Line2({ 2, 3 }),
+        Element::Line2({ 3, 4 }),
+    };
+    Mesh mesh(points, elements);
+    auto vols = compute_volume(mesh);
+    EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(5., 1e-10))));
 }
 
 TEST(ComputeVolumeTest, area_of_a_square)

--- a/test/src/ComputeVolume_test.cpp
+++ b/test/src/ComputeVolume_test.cpp
@@ -68,6 +68,48 @@ TEST(ComputeVolumeTest, volume_of_a_hex8)
     EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(1., 1e-10))));
 }
 
+TEST(ComputeVolumeTest, volume_of_a_hex8_blocks)
+{
+    // 2x2x2 grid of HEX8 elements in a 2x3x4 domain
+    // Points: 3x3x3 = 27 points
+    // x: 0, 1, 2
+    // y: 0, 1.5, 3
+    // z: 0, 2, 4
+    std::vector<Point> pts;
+    for (int k = 0; k < 3; ++k)
+        for (int j = 0; j < 3; ++j)
+            for (int i = 0; i < 3; ++i)
+                pts.push_back(Point(i * 1.0, j * 1.5, k * 2.0));
+
+    auto idx = [](int i, int j, int k) {
+        return i + j * 3 + k * 9;
+    };
+
+    std::vector<Element> elements;
+    for (int k = 0; k < 2; ++k)
+        for (int j = 0; j < 2; ++j)
+            for (int i = 0; i < 2; ++i)
+                elements.push_back(Element::Hex8({ (Index) idx(i, j, k),
+                                                   (Index) idx(i + 1, j, k),
+                                                   (Index) idx(i + 1, j + 1, k),
+                                                   (Index) idx(i, j + 1, k),
+                                                   (Index) idx(i, j, k + 1),
+                                                   (Index) idx(i + 1, j, k + 1),
+                                                   (Index) idx(i + 1, j + 1, k + 1),
+                                                   (Index) idx(i, j + 1, k + 1) }));
+
+    Mesh mesh(pts, elements);
+    // Block 1: 1 element (expected volume 1 * 1.5 * 2 = 3.0)
+    mesh.set_cell_set(10, { 0 });
+    // Block 2: 7 elements (expected volume 7 * 3.0 = 21.0)
+    mesh.set_cell_set(20, { 1, 2, 3, 4, 5, 6, 7 });
+
+    auto vols = compute_volume(mesh);
+    EXPECT_THAT(
+        vols,
+        UnorderedElementsAre(Pair(10, DoubleNear(3., 1e-10)), Pair(20, DoubleNear(21., 1e-10))));
+}
+
 TEST(ComputeVolumeTest, volume_of_a_prism6)
 {
     std::vector<Point> points = {

--- a/test/src/ComputeVolume_test.cpp
+++ b/test/src/ComputeVolume_test.cpp
@@ -167,6 +167,44 @@ TEST(ComputeVolumeTest, volume_of_a_pyramid5)
     EXPECT_THAT(vols, ElementsAre(Pair(0, DoubleNear(4. / 3., 1e-10))));
 }
 
+TEST(ComputeVolumeTest, volume_of_a_pyramid5_blocks)
+{
+    // 2x3x5 box, split into 6 pyramids with a central node at (1, 1.5, 2.5)
+    // Points: 8 box vertices + 1 central point = 9 points
+    std::vector<Point> pts = {
+        Point(0, 0, 0), // 0
+        Point(2, 0, 0), // 1
+        Point(2, 3, 0), // 2
+        Point(0, 3, 0), // 3
+        Point(0, 0, 5), // 4
+        Point(2, 0, 5), // 5
+        Point(2, 3, 5), // 6
+        Point(0, 3, 5), // 7
+        Point(1, 1.5, 2.5), // 8 (Apex)
+    };
+
+    std::vector<Element> elements = {
+        Element::Pyramid5({ 0, 3, 2, 1, 8 }), // Bottom (z=0)
+        Element::Pyramid5({ 4, 5, 6, 7, 8 }), // Top (z=5)
+        Element::Pyramid5({ 0, 1, 5, 4, 8 }), // Front (y=0)
+        Element::Pyramid5({ 3, 7, 6, 2, 8 }), // Back (y=3)
+        Element::Pyramid5({ 0, 4, 7, 3, 8 }), // Left (x=0)
+        Element::Pyramid5({ 1, 2, 6, 5, 8 }), // Right (x=2)
+    };
+
+    Mesh mesh(pts, elements);
+    // All pyramids have volume 5.0.
+    // Block 1: 1 pyramid (expected volume 1 * 5.0 = 5.0)
+    mesh.set_cell_set(10, { 0 });
+    // Block 2: 5 pyramids (expected volume 5 * 5.0 = 25.0)
+    mesh.set_cell_set(20, { 1, 2, 3, 4, 5 });
+
+    auto vols = compute_volume(mesh);
+    EXPECT_THAT(
+        vols,
+        UnorderedElementsAre(Pair(10, DoubleNear(5.0, 1e-10)), Pair(20, DoubleNear(25.0, 1e-10))));
+}
+
 TEST(ComputeVolumeTest, area_of_a_quad4_blocks)
 {
     // Domain: 4x2


### PR DESCRIPTION
- Improving element type support in `compute_volume`
- Redoing `ComputeVolumeTest.length_of_a_line` test
- Adding test for `compute_volume` on 2x2 grid with QUAD4s
- Adding test for `compute_volume` on 2x2x2 grid with HEX8s
- Adding test for compute_volume on domain with PRISM6s
- Adding test for compute_volume on domain with PYRAMID5s
